### PR TITLE
Add custom shipping carrier validation for checkout

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="checkout.root">
+            <arguments>
+                <argument name="jsLayout" xsi:type="array">
+                    <item name="components" xsi:type="array">
+                        <item name="checkout" xsi:type="array">
+                            <item name="children" xsi:type="array">
+                                <item name="steps" xsi:type="array">
+                                    <item name="children" xsi:type="array">
+                                        <item name="shipping-step" xsi:type="array">
+                                            <item name="children" xsi:type="array">
+                                                <item name="step-config" xsi:type="array">
+                                                    <item name="children" xsi:type="array">
+                                                        <item name="shipping-rates-validation" xsi:type="array">
+                                                            <item name="children" xsi:type="array">
+                                                                <item name="frenetshipping-rates-validation" xsi:type="array">
+                                                                    <item name="component" xsi:type="string">Frenet_Shipping/js/view/shipping-rates-validation/frenetshipping</item>
+                                                                </item>
+                                                            </item>
+                                                        </item>
+                                                    </item>
+                                                </item>
+                                            </item>
+                                        </item>
+                                    </item>
+                                </item>
+                            </item>
+                        </item>
+                    </item>
+                </argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/web/js/model/shipping-rates-validation-rules/frenetshipping.js
+++ b/view/frontend/web/js/model/shipping-rates-validation-rules/frenetshipping.js
@@ -1,0 +1,16 @@
+define([], function () {
+    'use strict';
+
+    return {
+        /**
+         * @return {Object}
+         */
+        getRules: function () {
+            return {
+                'country_id': {
+                    'required': true
+                }
+            };
+        }
+    };
+});

--- a/view/frontend/web/js/model/shipping-rates-validator/frenetshipping.js
+++ b/view/frontend/web/js/model/shipping-rates-validator/frenetshipping.js
@@ -1,0 +1,32 @@
+define([
+    'jquery',
+    'mageUtils',
+    '../shipping-rates-validation-rules/frenetshipping',
+    'mage/translate'
+], function ($, utils, validationRules, $t) {
+    'use strict';
+
+    return {
+        validationErrors: [],
+
+        /**
+         * @param {Object} address
+         * @return {Boolean}
+         */
+        validate: function (address) {
+            var self = this;
+
+            this.validationErrors = [];
+            $.each(validationRules.getRules(), function (field, rule) {
+                var message;
+
+                if (rule.required && utils.isEmpty(address[field])) {
+                    message = $t('Field ') + field + $t(' is required.');
+                    self.validationErrors.push(message);
+                }
+            });
+
+            return !this.validationErrors.length;
+        }
+    };
+});

--- a/view/frontend/web/js/view/shipping-rates-validation/frenetshipping.js
+++ b/view/frontend/web/js/view/shipping-rates-validation/frenetshipping.js
@@ -1,0 +1,20 @@
+define([
+    'uiComponent',
+    'Magento_Checkout/js/model/shipping-rates-validator',
+    'Magento_Checkout/js/model/shipping-rates-validation-rules',
+    '../../model/shipping-rates-validator/frenetshipping',
+    '../../model/shipping-rates-validation-rules/frenetshipping'
+], function (
+    Component,
+    defaultShippingRatesValidator,
+    defaultShippingRatesValidationRules,
+    frenetshippingShippingRatesValidator,
+    frenetshippingShippingRatesValidationRules
+) {
+    'use strict';
+
+    defaultShippingRatesValidator.registerValidator('frenetshipping', frenetshippingShippingRatesValidator);
+    defaultShippingRatesValidationRules.registerRules('frenetshipping', frenetshippingShippingRatesValidationRules);
+
+    return Component;
+});


### PR DESCRIPTION
### Create a custom shipping carrier validation.
In the current version, when frenet shipping is the only active shipping method, in checkout shipping step the shipping methods loads only one time (when the page load).
I added a new validator to get the required informations to reload automatically the shipping methods when frenet is active.
[Magento Documentation](https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_carrier.html)

**steps to reproduce**

- Go to Magento admin panel, stores -> configuration -> sales -> shipping methods
- Active only frenet shipping
- Go to checkout (Product with weight, height, width and length)
- Change the postcode input.
- Shipping methods don't update.

**steps to reproduce when fix is active**

- The same steps up
- But shipping methods update