### PR TITLE
hotfix: prevent exception on error logging

### DIFF
--- a/Model/Carrier/Frenet.php
+++ b/Model/Carrier/Frenet.php
@@ -179,7 +179,7 @@ class Frenet extends AbstractCarrierOnline implements CarrierInterface
     {
         if (!$this->canCollectRates()) {
             $errorMessage = $this->getErrorMessage();
-            $this->_logger->debug("Frenet canCollectRates: " . $errorMessage);
+            $this->_logger->debug("Frenet canCollectRates: {$errorMessage->getErrorMessage()}");
 
             return $errorMessage;
         }


### PR DESCRIPTION
Due to the `$errorMessage` variable on [line 181](https://github.com/FrenetGatewaydeFretes/frenet-magento2/blob/2.2-develop/Model/Carrier/Frenet.php#L181) being of type object (returned by `Magento\Shipping\Model\Carrier\AbstractCarrierOnline::getErrorMessage()`), the error logging was causing a exception like this on checkout:

> Error: Object of class Magento\Quote\Model\Quote\Address\RateResult\Error could not be converted to string in /app/vendor/frenet/frenet-magento2/Model/Carrier/Frenet.php:181

This PR solves this by using the correct getErrorMessage string on logging.
Tested on Magento 2.4.3-p1 with PHP 7.4.