### PR TITLE
feat: add (optional) timeout config to prevent checkout crashes (error 504)

### DIFF
--- a/Model/Packages/PackageProcessor.php
+++ b/Model/Packages/PackageProcessor.php
@@ -140,8 +140,16 @@ class PackageProcessor
      */
     private function callService(): array
     {
+        $requestOptions = [];
+        if ($timeout = (int) $this->config->getCarrierConfig('timeout')) {
+            $requestOptions['timeout'] = $timeout;
+        }
+
         /** @var \Frenet\ObjectType\Entity\Shipping\Quote $result */
-        $result = $this->serviceQuote->execute();
+        $result = $this->serviceQuote
+            ->setRequestOptions($requestOptions)
+            ->execute();
+
         $services = $result->getShippingServices();
 
         return $services ?: [];

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "frenet/frenet-php": "^1.1.0",
+        "frenet/frenet-php": "^1.2.1",
         "symfony/finder": "^v5.0.0",
         "magento/framework": "^101.0.0|^102.0.0|^103.0.0",
         "magento/module-catalog": "*",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -46,6 +46,10 @@
                         <field id="show_shipping_forecast">1</field>
                     </depends>
                 </field>
+                <field id="timeout" translate="label comment" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Timeout (in seconds)</label>
+                    <comment>Kill the request after the specified time to prevent checkout crashes. Use 0 to disable this.</comment>
+                </field>
 
                 <!-- MULTI QUOTE ENABLED -->
                 <field id="multi_quote" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -38,6 +38,7 @@
                 <sallowspecific>0</sallowspecific>
                 <show_shipping_forecast>1</show_shipping_forecast>
                 <shipping_forecast_message>{{d}} dia(s)</shipping_forecast_message>
+                <timeout>0</timeout>
 
                 <!-- ATTRIBUTES MAPPING -->
                 <attributes_mapping>

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -41,3 +41,5 @@
 "(Installed via Composer)","(Instalado via Composer)"
 "(Installed in app/code)","(Instalado em app/code)"
 "Unknown Module Version","Versão Desconhecida"
+"Timeout (in seconds)","Timeout (em segundos)"
+"Kill the request after the specified time to prevent checkout crashes. Use 0 to disable this.","Mata a requisição após o tempo especificado para prevenir que o checkout saia do ar em caso de indisponibilidade da API. Use 0 para desabilitar esse recurso."


### PR DESCRIPTION
Adds a new config to allow a timeout to be set (this prevents error 504 in checkout in case of api instabilities):
![image](https://user-images.githubusercontent.com/4603111/182178941-ac8d15f0-1eb4-44de-8983-7444c89a67ec.png)

Some notes:
 - **this feature is disabled by default**, so unless the storekeeper explicitly enables this it will not affect the current behavior at all;
 - it relies on [this enhancement](https://github.com/FrenetGatewaydeFretes/frenet-php/pull/7) on the php lib, and **after the lib version update there this MUST BE reflected in the composer.json of this module** (preview: `https://github.com/FrenetGatewaydeFretes/frenet-magento2/pull/24/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L12`);
 - also, [Déjà vu](https://github.com/FrenetGatewaydeFretes/frenet_magento/pull/13)!