### PR TITLE
:arrow_up: Update Frenet's Magento 2 module to be compatible with M2.4.8

### DIFF
--- a/Model/Formatters/PostcodeNormalizer.php
+++ b/Model/Formatters/PostcodeNormalizer.php
@@ -25,7 +25,7 @@ class PostcodeNormalizer
      *
      * @return string
      */
-    public function format(string $postcode = null)
+    public function format(?string $postcode = null)
     {
         $postcode = preg_replace('/[^0-9]/', "", "".$postcode);
         $postcode = str_pad($postcode, 8, '0', STR_PAD_LEFT);

--- a/Model/TotalsCollector.php
+++ b/Model/TotalsCollector.php
@@ -67,7 +67,7 @@ class TotalsCollector
      *
      * @return float
      */
-    public function calculateQuoteDiscounts(Quote $quote = null) : float
+    public function calculateQuoteDiscounts(?Quote $quote = null) : float
     {
         return $this->iterateCollectors($this->getDiscounts(), $quote);
     }
@@ -77,7 +77,7 @@ class TotalsCollector
      *
      * @return float
      */
-    public function calculateQuoteAdditions(Quote $quote = null) : float
+    public function calculateQuoteAdditions(?Quote $quote = null) : float
     {
         return $this->iterateCollectors($this->getAdditions(), $quote);
     }
@@ -88,7 +88,7 @@ class TotalsCollector
      *
      * @return float
      */
-    private function iterateCollectors(array $collectors = [], Quote $quote = null) : float
+    private function iterateCollectors(array $collectors = [], ?Quote $quote = null) : float
     {
         $total = 0.0000;
         $quote = $this->getQuote($quote);
@@ -105,7 +105,7 @@ class TotalsCollector
      *
      * @return Quote
      */
-    private function getQuote(Quote $quote = null)
+    private function getQuote(?Quote $quote = null)
     {
         if (!$quote) {
             return $this->checkoutSession->getQuote();

--- a/Model/Validator/PostcodeValidator.php
+++ b/Model/Validator/PostcodeValidator.php
@@ -36,7 +36,7 @@ class PostcodeValidator
      *
      * @return bool
      */
-    public function validate(string $postcode = null): bool
+    public function validate(?string $postcode = null): bool
     {
         if (empty($postcode)) {
             return false;

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^7.0|>=8.0",
-        "frenet/frenet-php": "^1.3.1",
+        "frenet/frenet-php": "^1.3.2",
         "symfony/finder": "^v6.4",
         "magento/framework": "^101.0.0|^102.0.0|^103.0.0|^104.0.0",
         "magento/module-catalog": "^101.0.0|^102.0.0|^103.0.0|^104.0.0",


### PR DESCRIPTION
Esta atividade contempla as seguintes mudanças:

- Modifica assinatura do método para aceitar parametros nulos e ficar consistente com a versão 8.4 do php.
- Atualiza a dependencia do modulo da frenet-php para a nova versão 1.3.2