### PR TITLE
:bookmark: Release frenet module version 2.4.8-p1.

### DIFF
--- a/Controller/Product/Quote.php
+++ b/Controller/Product/Quote.php
@@ -16,10 +16,13 @@ declare(strict_types=1);
 
 namespace Frenet\Shipping\Controller\Product;
 
+use Frenet\Shipping\Api\QuoteProductInterface;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
 
 /**
  * Class Quote
@@ -30,28 +33,21 @@ class Quote extends Action implements HttpPostActionInterface
 {
     /**
      * Maximum quantity accepted for a single shipping quote request.
-     *
-     * This endpoint builds an in-memory quote item directly from the
-     * request, bypassing the cart's own qty validation. A crafted qty
-     * value would otherwise be free to inflate the number of shipping
-     * packages (and outbound API calls to Frenet, one per package - see
-     * PackagesCalculator::processPackages()) that a single request can
-     * trigger, regardless of the product's configured weight.
      */
     private const MAX_QTY = 1000;
 
     /**
-     * @var \Frenet\Shipping\Api\QuoteProductInterface
+     * @var QuoteProductInterface
      */
     private $quoteProduct;
 
     /**
-     * @param Context                                    $context
-     * @param \Frenet\Shipping\Api\QuoteProductInterface $quoteProduct
+     * @param Context               $context
+     * @param QuoteProductInterface $quoteProduct
      */
     public function __construct(
         Context $context,
-        \Frenet\Shipping\Api\QuoteProductInterface $quoteProduct
+        QuoteProductInterface $quoteProduct
     ) {
         parent::__construct($context);
         $this->quoteProduct = $quoteProduct;
@@ -60,7 +56,7 @@ class Quote extends Action implements HttpPostActionInterface
     /**
      * Handles the AJAX shipping quote request for a single product.
      *
-     * @return \Magento\Framework\Controller\ResultInterface
+     * @return ResultInterface
      */
     public function execute()
     {
@@ -69,7 +65,7 @@ class Quote extends Action implements HttpPostActionInterface
         $qty = (int) $this->getRequest()->getParam('qty');
         $options = (array) $this->getRequest()->getParams();
 
-        /** @var \Magento\Framework\Controller\Result\Json $page */
+        /** @var Json $page */
         $page = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
         if ($qty <= 0 || $qty > self::MAX_QTY) {
@@ -93,12 +89,12 @@ class Quote extends Action implements HttpPostActionInterface
     /**
      * Builds a JSON error response.
      *
-     * @param \Magento\Framework\Controller\Result\Json $page
-     * @param string                                    $message
+     * @param Json   $page
+     * @param string $message
      *
-     * @return \Magento\Framework\Controller\Result\Json
+     * @return Json
      */
-    private function jsonError(\Magento\Framework\Controller\Result\Json $page, string $message): \Magento\Framework\Controller\Result\Json
+    private function jsonError(Json $page, string $message): Json
     {
         return $page->setData([
             'error'   => true,

--- a/Controller/Product/Quote.php
+++ b/Controller/Product/Quote.php
@@ -45,6 +45,10 @@ class Quote extends Action implements HttpPostActionInterface
      */
     private $quoteProduct;
 
+    /**
+     * @param Context                                    $context
+     * @param \Frenet\Shipping\Api\QuoteProductInterface $quoteProduct
+     */
     public function __construct(
         Context $context,
         \Frenet\Shipping\Api\QuoteProductInterface $quoteProduct
@@ -54,6 +58,8 @@ class Quote extends Action implements HttpPostActionInterface
     }
 
     /**
+     * Handles the AJAX shipping quote request for a single product.
+     *
      * @return \Magento\Framework\Controller\ResultInterface
      */
     public function execute()
@@ -85,6 +91,8 @@ class Quote extends Action implements HttpPostActionInterface
     }
 
     /**
+     * Builds a JSON error response.
+     *
      * @param \Magento\Framework\Controller\Result\Json $page
      * @param string                                    $message
      *

--- a/Controller/Product/Quote.php
+++ b/Controller/Product/Quote.php
@@ -27,6 +27,18 @@ use Magento\Framework\Controller\ResultFactory;
 class Quote extends Action implements HttpPostActionInterface
 {
     /**
+     * Maximum quantity accepted for a single shipping quote request.
+     *
+     * This endpoint builds an in-memory quote item directly from the
+     * request, bypassing the cart's own qty validation. A crafted qty
+     * value would otherwise be free to inflate the number of shipping
+     * packages (and outbound API calls to Frenet, one per package - see
+     * PackagesCalculator::processPackages()) that a single request can
+     * trigger, regardless of the product's configured weight.
+     */
+    private const MAX_QTY = 1000;
+
+    /**
      * @var \Frenet\Shipping\Api\QuoteProductInterface
      */
     private $quoteProduct;
@@ -49,9 +61,19 @@ class Quote extends Action implements HttpPostActionInterface
         $qty = (float) $this->getRequest()->getParam('qty');
         $options = (array) $this->getRequest()->getParams();
 
+        /** @var \Magento\Framework\Controller\Result\Json $page */
+        $page = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+
+        if ($qty <= 0 || $qty > self::MAX_QTY) {
+            $page->setData([
+                'error'   => true,
+                'message' => __('Invalid quantity informed.')
+            ]);
+
+            return $page;
+        }
+
         try {
-            /** @var \Magento\Framework\Controller\Result\Json $result */
-            $page = $this->resultFactory->create(ResultFactory::TYPE_JSON);
             $rates = $this->quoteProduct->quoteByProductId($productId, $postcode, $qty, $options);
 
             $page->setData([

--- a/Controller/Product/Quote.php
+++ b/Controller/Product/Quote.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Frenet\Shipping\Controller\Product;
 
 use Frenet\Shipping\Api\QuoteProductInterface;
+use Frenet\Shipping\Model\Config;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
@@ -32,25 +33,28 @@ use Magento\Framework\Controller\ResultInterface;
 class Quote extends Action implements HttpPostActionInterface
 {
     /**
-     * Maximum quantity accepted for a single shipping quote request.
-     */
-    private const MAX_QTY = 1000;
-
-    /**
      * @var QuoteProductInterface
      */
     private $quoteProduct;
 
     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
      * @param Context               $context
      * @param QuoteProductInterface $quoteProduct
+     * @param Config                $config
      */
     public function __construct(
         Context $context,
-        QuoteProductInterface $quoteProduct
+        QuoteProductInterface $quoteProduct,
+        Config $config
     ) {
         parent::__construct($context);
         $this->quoteProduct = $quoteProduct;
+        $this->config = $config;
     }
 
     /**
@@ -68,7 +72,7 @@ class Quote extends Action implements HttpPostActionInterface
         /** @var Json $page */
         $page = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
-        if ($qty <= 0 || $qty > self::MAX_QTY) {
+        if ($qty <= 0 || $qty > $this->config->getMaxUnitQuantity()) {
             return $this->jsonError($page, (string) __('Invalid quantity informed.'));
         }
 

--- a/Controller/Product/Quote.php
+++ b/Controller/Product/Quote.php
@@ -12,6 +12,8 @@
  * Copyright (c) 2020.
  */
 
+declare(strict_types=1);
+
 namespace Frenet\Shipping\Controller\Product;
 
 use Magento\Framework\App\Action\Action;
@@ -58,7 +60,7 @@ class Quote extends Action implements HttpPostActionInterface
     {
         $productId = (int) $this->getRequest()->getParam('product');
         $postcode = (string) $this->getRequest()->getParam('postcode');
-        $qty = (float) $this->getRequest()->getParam('qty');
+        $qty = (int) $this->getRequest()->getParam('qty');
         $options = (array) $this->getRequest()->getParams();
 
         /** @var \Magento\Framework\Controller\Result\Json $page */

--- a/Controller/Product/Quote.php
+++ b/Controller/Product/Quote.php
@@ -67,12 +67,7 @@ class Quote extends Action implements HttpPostActionInterface
         $page = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
         if ($qty <= 0 || $qty > self::MAX_QTY) {
-            $page->setData([
-                'error'   => true,
-                'message' => __('Invalid quantity informed.')
-            ]);
-
-            return $page;
+            return $this->jsonError($page, (string) __('Invalid quantity informed.'));
         }
 
         try {
@@ -83,12 +78,23 @@ class Quote extends Action implements HttpPostActionInterface
                 'rates' => $rates
             ]);
         } catch (\Exception $exception) {
-            $page->setData([
-                'error'   => true,
-                'message' => $exception->getMessage()
-            ]);
+            $this->jsonError($page, $exception->getMessage());
         }
 
         return $page;
+    }
+
+    /**
+     * @param \Magento\Framework\Controller\Result\Json $page
+     * @param string                                    $message
+     *
+     * @return \Magento\Framework\Controller\Result\Json
+     */
+    private function jsonError(\Magento\Framework\Controller\Result\Json $page, string $message): \Magento\Framework\Controller\Result\Json
+    {
+        return $page->setData([
+            'error'   => true,
+            'message' => $message
+        ]);
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -216,6 +216,18 @@ class Config
     }
 
     /**
+     * Returns the maximum weight allowed per shipping package, in kilograms.
+     *
+     * @param string|int|StoreInterface $store
+     *
+     * @return float
+     */
+    public function getPackageMaxWeight($store = null): float
+    {
+        return (float) $this->getCarrierConfig('package_max_weight', $store);
+    }
+
+    /**
      * Maximum quantity of a single cart item considered when building shipping packages.
      *
      * @param string|int|StoreInterface $store

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -15,7 +15,10 @@ declare(strict_types=1);
 
 namespace Frenet\Shipping\Model;
 
-use \Magento\Store\Model\ScopeInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class Config
@@ -23,22 +26,22 @@ use \Magento\Store\Model\ScopeInterface;
 class Config
 {
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
     private $scopeConfig;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     private $storeManager;
 
     /**
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-     * @param \Magento\Store\Model\StoreManagerInterface         $storeManager
+     * @param ScopeConfigInterface  $scopeConfig
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        ScopeConfigInterface $scopeConfig,
+        StoreManagerInterface $storeManager
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
@@ -47,7 +50,7 @@ class Config
     /**
      * Checks whether the Frenet shipping method is active.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return bool
      */
@@ -59,7 +62,7 @@ class Config
     /**
      * Returns the Frenet API token.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -71,7 +74,7 @@ class Config
     /**
      * Returns the product attribute code mapped to weight.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -83,7 +86,7 @@ class Config
     /**
      * Returns the product attribute code mapped to height.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -95,7 +98,7 @@ class Config
     /**
      * Returns the product attribute code mapped to length.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -107,7 +110,7 @@ class Config
     /**
      * Returns the product attribute code mapped to width.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -119,7 +122,7 @@ class Config
     /**
      * Returns the default weight used when a product has none.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return float
      */
@@ -131,7 +134,7 @@ class Config
     /**
      * Returns the default height used when a product has none.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return float
      */
@@ -143,7 +146,7 @@ class Config
     /**
      * Returns the default length used when a product has none.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return float
      */
@@ -155,7 +158,7 @@ class Config
     /**
      * Returns the default width used when a product has none.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return float
      */
@@ -167,7 +170,7 @@ class Config
     /**
      * Returns the additional lead time, in days, added to the delivery estimate.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return int
      */
@@ -179,7 +182,7 @@ class Config
     /**
      * Checks whether the shipping forecast message should be shown.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return bool
      */
@@ -191,7 +194,7 @@ class Config
     /**
      * Returns the shipping forecast message template.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -203,7 +206,7 @@ class Config
     /**
      * Checks whether multi-quote (package splitting) is enabled.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return bool
      */
@@ -220,7 +223,7 @@ class Config
      * a single cart line can generate, regardless of the product's
      * configured weight.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return int
      */
@@ -232,7 +235,7 @@ class Config
     /**
      * Checks whether debug mode is enabled.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return bool
      */
@@ -244,7 +247,7 @@ class Config
     /**
      * Returns the debug log filename.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -256,7 +259,7 @@ class Config
     /**
      * Checks whether the product-page shipping quote widget is enabled.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return bool
      */
@@ -268,8 +271,8 @@ class Config
     /**
      * Checks whether the given product type may use the product-page shipping quote widget.
      *
-     * @param string                                            $productTypeId
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string                    $productTypeId
+     * @param string|int|StoreInterface $store
      *
      * @return bool
      */
@@ -282,7 +285,7 @@ class Config
     /**
      * Returns the product types allowed to use the product-page shipping quote widget.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return array
      */
@@ -297,7 +300,7 @@ class Config
     /**
      * Returns the shipping origin postcode.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
      * @return string
      */
@@ -309,8 +312,8 @@ class Config
     /**
      * Returns a carrier-scoped configuration value.
      *
-     * @param string                                            $field
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string                    $field
+     * @param string|int|StoreInterface $store
      *
      * @return mixed
      */
@@ -322,11 +325,11 @@ class Config
     /**
      * Returns a configuration value for the given section, group and field.
      *
-     * @param string                                            $section
-     * @param string                                            $group
-     * @param string                                            $field
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
-     * @param string                                            $scopeType
+     * @param string                    $section
+     * @param string                    $group
+     * @param string                    $field
+     * @param string|int|StoreInterface $store
+     * @param string                    $scopeType
      *
      * @return mixed
      */
@@ -339,9 +342,9 @@ class Config
     /**
      * Resolves the store to use, falling back to the default store view.
      *
-     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     * @param string|int|StoreInterface $store
      *
-     * @return \Magento\Store\Api\Data\StoreInterface|null
+     * @return StoreInterface|null
      */
     private function getStore($store = null)
     {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -32,6 +32,10 @@ class Config
      */
     private $storeManager;
 
+    /**
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Store\Model\StoreManagerInterface         $storeManager
+     */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Store\Model\StoreManagerInterface $storeManager
@@ -41,6 +45,8 @@ class Config
     }
 
     /**
+     * Checks whether the Frenet shipping method is active.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return bool
@@ -51,6 +57,8 @@ class Config
     }
 
     /**
+     * Returns the Frenet API token.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -61,6 +69,8 @@ class Config
     }
 
     /**
+     * Returns the product attribute code mapped to weight.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -71,6 +81,8 @@ class Config
     }
 
     /**
+     * Returns the product attribute code mapped to height.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -81,6 +93,8 @@ class Config
     }
 
     /**
+     * Returns the product attribute code mapped to length.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -91,6 +105,8 @@ class Config
     }
 
     /**
+     * Returns the product attribute code mapped to width.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -101,6 +117,8 @@ class Config
     }
 
     /**
+     * Returns the default weight used when a product has none.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return float
@@ -111,6 +129,8 @@ class Config
     }
 
     /**
+     * Returns the default height used when a product has none.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return float
@@ -121,6 +141,8 @@ class Config
     }
 
     /**
+     * Returns the default length used when a product has none.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return float
@@ -131,6 +153,8 @@ class Config
     }
 
     /**
+     * Returns the default width used when a product has none.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return float
@@ -141,6 +165,8 @@ class Config
     }
 
     /**
+     * Returns the additional lead time, in days, added to the delivery estimate.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return int
@@ -151,6 +177,8 @@ class Config
     }
 
     /**
+     * Checks whether the shipping forecast message should be shown.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return bool
@@ -161,6 +189,8 @@ class Config
     }
 
     /**
+     * Returns the shipping forecast message template.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -171,6 +201,8 @@ class Config
     }
 
     /**
+     * Checks whether multi-quote (package splitting) is enabled.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return bool
@@ -198,6 +230,8 @@ class Config
     }
 
     /**
+     * Checks whether debug mode is enabled.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return bool
@@ -208,6 +242,8 @@ class Config
     }
 
     /**
+     * Returns the debug log filename.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -218,6 +254,8 @@ class Config
     }
 
     /**
+     * Checks whether the product-page shipping quote widget is enabled.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return bool
@@ -228,6 +266,8 @@ class Config
     }
 
     /**
+     * Checks whether the given product type may use the product-page shipping quote widget.
+     *
      * @param string                                            $productTypeId
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
@@ -240,6 +280,8 @@ class Config
     }
 
     /**
+     * Returns the product types allowed to use the product-page shipping quote widget.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return array
@@ -253,6 +295,8 @@ class Config
     }
 
     /**
+     * Returns the shipping origin postcode.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return string
@@ -263,6 +307,8 @@ class Config
     }
 
     /**
+     * Returns a carrier-scoped configuration value.
+     *
      * @param string                                            $field
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
@@ -274,6 +320,8 @@ class Config
     }
 
     /**
+     * Returns a configuration value for the given section, group and field.
+     *
      * @param string                                            $section
      * @param string                                            $group
      * @param string                                            $field
@@ -289,6 +337,8 @@ class Config
     }
 
     /**
+     * Resolves the store to use, falling back to the default store view.
+     *
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return \Magento\Store\Api\Data\StoreInterface|null

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -218,11 +218,6 @@ class Config
     /**
      * Maximum quantity of a single cart item considered when building shipping packages.
      *
-     * Bounds how many shipping packages (and therefore outbound API calls to
-     * Frenet, one per package - see PackagesCalculator::processPackages())
-     * a single cart line can generate, regardless of the product's
-     * configured weight.
-     *
      * @param string|int|StoreInterface $store
      *
      * @return int

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -181,6 +181,23 @@ class Config
     }
 
     /**
+     * Maximum quantity of a single cart item considered when building shipping packages.
+     *
+     * Bounds how many shipping packages (and therefore outbound API calls to
+     * Frenet, one per package - see PackagesCalculator::processPackages())
+     * a single cart line can generate, regardless of the product's
+     * configured weight.
+     *
+     * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
+     *
+     * @return int
+     */
+    public function getMaxUnitQuantity($store = null): int
+    {
+        return (int) $this->getCarrierConfig('max_unit_quantity', $store);
+    }
+
+    /**
      * @param string|int|\Magento\Store\Api\Data\StoreInterface $store
      *
      * @return bool

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -68,14 +68,15 @@ class Package
     }
 
     /**
-     * @param QuoteItem $item
-     * @param int       $qty
+     * @param QuoteItem  $item
+     * @param int        $qty
+     * @param float|null $unitWeight Pre-computed unit weight (see planQuantitiesFor()); avoids re-extracting it.
      *
      * @return bool
      */
-    public function addItem(QuoteItem $item, $qty = 1)
+    public function addItem(QuoteItem $item, $qty = 1, ?float $unitWeight = null)
     {
-        if (!$this->canAddItem($item, $qty)) {
+        if (!$this->canAddItem($item, $qty, $unitWeight)) {
             return false;
         }
 
@@ -110,20 +111,22 @@ class Package
     }
 
     /**
-     * @param QuoteItem $item
-     * @param int       $qty
+     * @param QuoteItem  $item
+     * @param int        $qty
+     * @param float|null $unitWeight Pre-computed unit weight (see planQuantitiesFor()); avoids re-extracting it.
      *
      * @return bool
      */
-    public function canAddItem(QuoteItem $item, $qty = 1)
+    public function canAddItem(QuoteItem $item, $qty = 1, ?float $unitWeight = null)
     {
         if ($qty <= 0) {
             return true;
         }
 
-        $this->dimensionsExtractor->setProductByCartItem($item);
-
-        $weight = $this->dimensionsExtractor->getWeight();
+        if ($unitWeight === null) {
+            $this->dimensionsExtractor->setProductByCartItem($item);
+            $unitWeight = (float) $this->dimensionsExtractor->getWeight();
+        }
 
         /**
          * A primeira unidade do lote é comparada usando o peso cru (igual
@@ -134,8 +137,8 @@ class Package
          * $qty > 1 seria comparado de forma inconsistente com a soma que
          * getTotalWeight() reporta para o mesmo lote depois de adicionado.
          */
-        $convertedWeight = (float) $this->weightConverter->convertToKg($weight);
-        $itemWeight = $weight + $convertedWeight * ($qty - 1);
+        $convertedWeight = (float) $this->weightConverter->convertToKg($unitWeight);
+        $itemWeight = $unitWeight + $convertedWeight * ($qty - 1);
 
         if (($itemWeight + $this->getTotalWeight()) > $this->packageLimit->getMaxWeight()) {
             return false;
@@ -191,10 +194,13 @@ class Package
      * mistura cru/convertido, em vez de assumir peso uniforme dos dois
      * lados da conta.
      *
+     * Cada entrada também carrega o unitWeight já extraído aqui, para que
+     * quem consome o plano não precise reextraí-lo por lote.
+     *
      * @param QuoteItem $item
      * @param float     $requestedQty
      *
-     * @return array{newPackage: bool, qty: float}[]
+     * @return array{newPackage: bool, qty: float, unitWeight: float}[]
      */
     public function planQuantitiesFor(QuoteItem $item, float $requestedQty): array
     {
@@ -202,7 +208,7 @@ class Package
         $unitWeight = (float) $this->dimensionsExtractor->getWeight();
 
         if ($unitWeight <= 0) {
-            return [['newPackage' => false, 'qty' => $requestedQty]];
+            return [['newPackage' => false, 'qty' => $requestedQty, 'unitWeight' => $unitWeight]];
         }
 
         $convertedUnitWeight = (float) $this->weightConverter->convertToKg($unitWeight);
@@ -235,7 +241,7 @@ class Package
         $plan = [];
 
         if ($firstBatch > 0) {
-            $plan[] = ['newPackage' => false, 'qty' => (float) $firstBatch];
+            $plan[] = ['newPackage' => false, 'qty' => (float) $firstBatch, 'unitWeight' => $unitWeight];
         }
 
         $fullPackagesCount = intdiv($remaining, $unitsPerFullPackage);
@@ -244,12 +250,16 @@ class Package
         if ($fullPackagesCount > 0) {
             $plan = array_merge(
                 $plan,
-                array_fill(0, $fullPackagesCount, ['newPackage' => true, 'qty' => (float) $unitsPerFullPackage])
+                array_fill(
+                    0,
+                    $fullPackagesCount,
+                    ['newPackage' => true, 'qty' => (float) $unitsPerFullPackage, 'unitWeight' => $unitWeight]
+                )
             );
         }
 
         if ($leftover > 0) {
-            $plan[] = ['newPackage' => true, 'qty' => (float) $leftover];
+            $plan[] = ['newPackage' => true, 'qty' => (float) $leftover, 'unitWeight' => $unitWeight];
         }
 
         return $plan;

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -25,8 +25,7 @@ use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
 class Package
 {
     /**
-     * Precision (decimal places) used when scaling weights to integers for
-     * planQuantitiesFor(), matching PackageLimit::PACKAGE_MAX_WEIGHT's precision.
+     * Scale factor used to convert weights to integers for exact packing arithmetic.
      */
     private const WEIGHT_SCALE = 10000;
 
@@ -78,7 +77,7 @@ class Package
      *
      * @param QuoteItem  $item
      * @param int        $qty
-     * @param float|null $unitWeight Pre-computed unit weight (see planQuantitiesFor()); avoids re-extracting it.
+     * @param float|null $unitWeight
      *
      * @return bool
      */
@@ -127,7 +126,7 @@ class Package
      *
      * @param QuoteItem  $item
      * @param int        $qty
-     * @param float|null $unitWeight Pre-computed unit weight (see planQuantitiesFor()); avoids re-extracting it.
+     * @param float|null $unitWeight
      *
      * @return bool
      */
@@ -142,12 +141,6 @@ class Package
             $unitWeight = (float) $this->dimensionsExtractor->getWeight();
         }
 
-        /**
-         * The batch's first unit is compared using the raw weight (matching
-         * the original $qty=1 behavior); each additional unit adds the
-         * converted weight, the same basis getTotalWeight() accumulates
-         * (via PackageItem::getTotalWeight() -> WeightConverter::convertToKg()).
-         */
         $convertedWeight = (float) $this->weightConverter->convertToKg($unitWeight);
         $itemWeight = $unitWeight + $convertedWeight * ($qty - 1);
 
@@ -188,26 +181,6 @@ class Package
     /**
      * Plans how to distribute a quantity of an item across packages.
      *
-     * Computed entirely through integer division/modulo (no while/for tied
-     * to $requestedQty). Each entry carries how many units go in, whether a
-     * new package needs to be opened first, and the unit weight already
-     * extracted here, so callers don't need to re-extract it per batch.
-     *
-     * The first batch (newPackage => false) only appears when something
-     * still fits in the current package (which may already be partially
-     * filled by a previous item); subsequent batches (newPackage => true)
-     * always assume a fresh, empty package at full capacity.
-     *
-     * canAddItem() compares the item's *raw* weight against the *converted
-     * to kg* weight already accumulated in the package (getTotalWeight()
-     * sums PackageItem::getTotalWeight(), which goes through
-     * WeightConverter::convertToKg()) -- a pre-existing inconsistency that
-     * only surfaces when the store isn't configured in kg
-     * (general/locale/weight_unit != "kgs", itself Magento_Directory's
-     * factory default). unitsFitting() replicates that same raw/converted
-     * mix so the packing result stays identical to the old unit-by-unit
-     * algorithm even in that scenario.
-     *
      * @param QuoteItem $item
      * @param float     $requestedQty
      *
@@ -232,9 +205,6 @@ class Package
         $unitsPerFullPackage = $this->unitsFitting($fullCapacityScaled, $unitWeightScaled, $convertedUnitWeightScaled);
 
         if ($unitsPerFullPackage < 1) {
-            // Unit weight alone exceeds the limit of even an empty package.
-            // Inherited behavior: the previous unit-by-unit algorithm also
-            // silently dropped this item (via canAddItem() returning false).
             return [];
         }
 
@@ -275,10 +245,6 @@ class Package
     /**
      * Computes how many units fit in a given weight capacity.
      *
-     * Replicates canAddItem()'s semantics: the first unit is compared using
-     * raw weight; each additional unit adds the converted weight (the same
-     * basis getTotalWeight() uses).
-     *
      * @param int $capacityScaled
      * @param int $rawUnitWeightScaled
      * @param int $convertedUnitWeightScaled
@@ -291,10 +257,6 @@ class Package
             return 0;
         }
 
-        // Guards against a custom WeightConverterInterface (a DI extension
-        // point) returning 0 for a positive weight; the stock converter
-        // never does, but a division by zero here shouldn't be possible
-        // regardless of what's wired in via di.xml.
         return intdiv($capacityScaled - $rawUnitWeightScaled, max($convertedUnitWeightScaled, 1)) + 1;
     }
 

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -24,6 +24,12 @@ use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
 class Package
 {
     /**
+     * Precision (decimal places) used when scaling weights to integers for
+     * planQuantitiesFor(), matching PackageLimit::PACKAGE_MAX_WEIGHT's precision.
+     */
+    private const WEIGHT_SCALE = 10000;
+
+    /**
      * @var array
      */
     private $items = [];
@@ -128,6 +134,84 @@ class Package
         }
 
         return (float) $total;
+    }
+
+    /**
+     * @return float
+     */
+    public function getRemainingWeight(): float
+    {
+        return $this->packageLimit->getMaxWeight() - $this->getTotalWeight();
+    }
+
+    /**
+     * Plano de como distribuir $requestedQty unidades de $item entre pacotes,
+     * calculado inteiramente por aritmética (divisão/módulo inteiros, sem
+     * while/for dependente da quantidade). Cada entrada indica quantas
+     * unidades entram num pacote e se é necessário abrir um pacote novo
+     * antes de adicioná-las.
+     *
+     * O primeiro lote (newPackage => false) só entra no plano quando cabe
+     * algo no pacote atual (que pode já estar parcialmente ocupado por um
+     * item anterior); os lotes seguintes (newPackage => true) assumem
+     * sempre um pacote novo e vazio, com capacidade cheia.
+     *
+     * @param QuoteItem $item
+     * @param float     $requestedQty
+     *
+     * @return array{newPackage: bool, qty: float}[]
+     */
+    public function planQuantitiesFor(QuoteItem $item, float $requestedQty): array
+    {
+        $this->dimensionsExtractor->setProductByCartItem($item);
+        $unitWeight = (float) $this->dimensionsExtractor->getWeight();
+
+        if ($unitWeight <= 0) {
+            return [['newPackage' => false, 'qty' => $requestedQty]];
+        }
+
+        $unitWeightScaled = (int) round($unitWeight * self::WEIGHT_SCALE);
+        $fullCapacityScaled = (int) round($this->packageLimit->getMaxWeight() * self::WEIGHT_SCALE);
+        $remainingScaled = max(0, (int) round($this->getRemainingWeight() * self::WEIGHT_SCALE));
+
+        $unitsPerFullPackage = intdiv($fullCapacityScaled, $unitWeightScaled);
+
+        if ($unitsPerFullPackage < 1) {
+            /**
+             * Peso unitário sozinho excede o limite mesmo de um pacote
+             * vazio. Comportamento herdado: o algoritmo unidade-por-unidade
+             * anterior também descartava esse item silenciosamente (via
+             * canAddItem() retornando false). Não introduzido por este
+             * método.
+             */
+            return [];
+        }
+
+        $requestedQtyInt = (int) $requestedQty;
+        $firstBatch = min($requestedQtyInt, intdiv($remainingScaled, $unitWeightScaled));
+        $remaining = $requestedQtyInt - $firstBatch;
+
+        $plan = [];
+
+        if ($firstBatch > 0) {
+            $plan[] = ['newPackage' => false, 'qty' => (float) $firstBatch];
+        }
+
+        $fullPackagesCount = intdiv($remaining, $unitsPerFullPackage);
+        $leftover = $remaining % $unitsPerFullPackage;
+
+        if ($fullPackagesCount > 0) {
+            $plan = array_merge(
+                $plan,
+                array_fill(0, $fullPackagesCount, ['newPackage' => true, 'qty' => (float) $unitsPerFullPackage])
+            );
+        }
+
+        if ($leftover > 0) {
+            $plan[] = ['newPackage' => true, 'qty' => (float) $leftover];
+        }
+
+        return $plan;
     }
 
     /**

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -129,13 +129,10 @@ class Package
         }
 
         /**
-         * A primeira unidade do lote é comparada usando o peso cru (igual
-         * ao comportamento original com $qty=1); as unidades seguintes do
-         * mesmo lote somam o peso convertido, que é a mesma base usada por
-         * getTotalWeight() (soma de PackageItem::getTotalWeight(), que já
-         * passa por WeightConverter::convertToKg()). Sem isso, um lote com
-         * $qty > 1 seria comparado de forma inconsistente com a soma que
-         * getTotalWeight() reporta para o mesmo lote depois de adicionado.
+         * The batch's first unit is compared using the raw weight (matching
+         * the original $qty=1 behavior); each additional unit adds the
+         * converted weight, the same basis getTotalWeight() accumulates
+         * (via PackageItem::getTotalWeight() -> WeightConverter::convertToKg()).
          */
         $convertedWeight = (float) $this->weightConverter->convertToKg($unitWeight);
         $itemWeight = $unitWeight + $convertedWeight * ($qty - 1);
@@ -171,31 +168,26 @@ class Package
     }
 
     /**
-     * Plano de como distribuir $requestedQty unidades de $item entre pacotes,
-     * calculado inteiramente por aritmética (divisão/módulo inteiros, sem
-     * while/for dependente da quantidade). Cada entrada indica quantas
-     * unidades entram num pacote e se é necessário abrir um pacote novo
-     * antes de adicioná-las.
+     * Plans how to distribute $requestedQty units of $item across packages,
+     * computed entirely through integer division/modulo (no while/for tied
+     * to $requestedQty). Each entry carries how many units go in, whether a
+     * new package needs to be opened first, and the unit weight already
+     * extracted here, so callers don't need to re-extract it per batch.
      *
-     * O primeiro lote (newPackage => false) só entra no plano quando cabe
-     * algo no pacote atual (que pode já estar parcialmente ocupado por um
-     * item anterior); os lotes seguintes (newPackage => true) assumem
-     * sempre um pacote novo e vazio, com capacidade cheia.
+     * The first batch (newPackage => false) only appears when something
+     * still fits in the current package (which may already be partially
+     * filled by a previous item); subsequent batches (newPackage => true)
+     * always assume a fresh, empty package at full capacity.
      *
-     * canAddItem() compara o peso *cru* do item sendo adicionado com o
-     * peso *convertido para kg* já acumulado no pacote (getTotalWeight()
-     * soma PackageItem::getTotalWeight(), que passa por
-     * WeightConverter::convertToKg()) -- uma inconsistência pré-existente
-     * que só produz efeito quando a loja não está configurada em kg
-     * (general/locale/weight_unit != "kgs", que é inclusive o valor
-     * padrão de fábrica do Magento_Directory). Para que o resultado do
-     * empacotamento continue idêntico ao algoritmo unidade-por-unidade
-     * mesmo nesse cenário, unitsFitting() replica exatamente essa mesma
-     * mistura cru/convertido, em vez de assumir peso uniforme dos dois
-     * lados da conta.
-     *
-     * Cada entrada também carrega o unitWeight já extraído aqui, para que
-     * quem consome o plano não precise reextraí-lo por lote.
+     * canAddItem() compares the item's *raw* weight against the *converted
+     * to kg* weight already accumulated in the package (getTotalWeight()
+     * sums PackageItem::getTotalWeight(), which goes through
+     * WeightConverter::convertToKg()) -- a pre-existing inconsistency that
+     * only surfaces when the store isn't configured in kg
+     * (general/locale/weight_unit != "kgs", itself Magento_Directory's
+     * factory default). unitsFitting() replicates that same raw/converted
+     * mix so the packing result stays identical to the old unit-by-unit
+     * algorithm even in that scenario.
      *
      * @param QuoteItem $item
      * @param float     $requestedQty
@@ -221,13 +213,9 @@ class Package
         $unitsPerFullPackage = $this->unitsFitting($fullCapacityScaled, $unitWeightScaled, $convertedUnitWeightScaled);
 
         if ($unitsPerFullPackage < 1) {
-            /**
-             * Peso unitário sozinho excede o limite mesmo de um pacote
-             * vazio. Comportamento herdado: o algoritmo unidade-por-unidade
-             * anterior também descartava esse item silenciosamente (via
-             * canAddItem() retornando false). Não introduzido por este
-             * método.
-             */
+            // Unit weight alone exceeds the limit of even an empty package.
+            // Inherited behavior: the previous unit-by-unit algorithm also
+            // silently dropped this item (via canAddItem() returning false).
             return [];
         }
 
@@ -266,11 +254,11 @@ class Package
     }
 
     /**
-     * Quantas unidades de peso cru $rawUnitWeightScaled (com equivalente
-     * convertido $convertedUnitWeightScaled) cabem numa capacidade
-     * $capacityScaled, replicando a semântica de canAddItem(): a primeira
-     * unidade é comparada usando peso cru; cada unidade adicional soma o
-     * peso convertido (mesma base usada por getTotalWeight()).
+     * How many units of raw weight $rawUnitWeightScaled (with converted
+     * equivalent $convertedUnitWeightScaled) fit in a $capacityScaled
+     * capacity, replicating canAddItem()'s semantics: the first unit is
+     * compared using raw weight; each additional unit adds the converted
+     * weight (the same basis getTotalWeight() uses).
      *
      * @param int $capacityScaled
      * @param int $rawUnitWeightScaled
@@ -284,8 +272,10 @@ class Package
             return 0;
         }
 
-        // Protege contra um WeightConverterInterface customizado (ponto de
-        // extensão via DI) que devolva 0 para um peso positivo.
+        // Guards against a custom WeightConverterInterface (a DI extension
+        // point) returning 0 for a positive weight; the stock converter
+        // never does, but a division by zero here shouldn't be possible
+        // regardless of what's wired in via di.xml.
         return intdiv($capacityScaled - $rawUnitWeightScaled, max($convertedUnitWeightScaled, 1)) + 1;
     }
 

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -284,7 +284,9 @@ class Package
             return 0;
         }
 
-        return intdiv($capacityScaled - $rawUnitWeightScaled, $convertedUnitWeightScaled) + 1;
+        // Protege contra um WeightConverterInterface customizado (ponto de
+        // extensão via DI) que devolva 0 para um peso positivo.
+        return intdiv($capacityScaled - $rawUnitWeightScaled, max($convertedUnitWeightScaled, 1)) + 1;
     }
 
     /**

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -55,6 +55,12 @@ class Package
      */
     private $weightConverter;
 
+    /**
+     * @param DimensionsExtractorInterface $dimensionsExtractor
+     * @param PackageItemFactory           $packageItemFactory
+     * @param PackageLimit                 $packageLimit
+     * @param WeightConverterInterface     $weightConverter
+     */
     public function __construct(
         DimensionsExtractorInterface $dimensionsExtractor,
         PackageItemFactory $packageItemFactory,
@@ -68,6 +74,8 @@ class Package
     }
 
     /**
+     * Adds a quantity of an item to the package.
+     *
      * @param QuoteItem  $item
      * @param int        $qty
      * @param float|null $unitWeight Pre-computed unit weight (see planQuantitiesFor()); avoids re-extracting it.
@@ -93,6 +101,8 @@ class Package
     }
 
     /**
+     * Returns the items currently in the package.
+     *
      * @return PackageItem[]
      */
     public function getItems()
@@ -101,6 +111,8 @@ class Package
     }
 
     /**
+     * Returns a package item by its cart item ID.
+     *
      * @param $itemId
      *
      * @return PackageItem|null
@@ -111,6 +123,8 @@ class Package
     }
 
     /**
+     * Checks whether a quantity of an item still fits within the package weight limit.
+     *
      * @param QuoteItem  $item
      * @param int        $qty
      * @param float|null $unitWeight Pre-computed unit weight (see planQuantitiesFor()); avoids re-extracting it.
@@ -145,6 +159,8 @@ class Package
     }
 
     /**
+     * Returns the total weight of all items in the package.
+     *
      * @return float
      */
     public function getTotalWeight()
@@ -160,6 +176,8 @@ class Package
     }
 
     /**
+     * Returns the weight capacity still available in the package.
+     *
      * @return float
      */
     public function getRemainingWeight(): float
@@ -168,8 +186,9 @@ class Package
     }
 
     /**
-     * Plans how to distribute $requestedQty units of $item across packages,
-     * computed entirely through integer division/modulo (no while/for tied
+     * Plans how to distribute a quantity of an item across packages.
+     *
+     * Computed entirely through integer division/modulo (no while/for tied
      * to $requestedQty). Each entry carries how many units go in, whether a
      * new package needs to be opened first, and the unit weight already
      * extracted here, so callers don't need to re-extract it per batch.
@@ -254,11 +273,11 @@ class Package
     }
 
     /**
-     * How many units of raw weight $rawUnitWeightScaled (with converted
-     * equivalent $convertedUnitWeightScaled) fit in a $capacityScaled
-     * capacity, replicating canAddItem()'s semantics: the first unit is
-     * compared using raw weight; each additional unit adds the converted
-     * weight (the same basis getTotalWeight() uses).
+     * Computes how many units fit in a given weight capacity.
+     *
+     * Replicates canAddItem()'s semantics: the first unit is compared using
+     * raw weight; each additional unit adds the converted weight (the same
+     * basis getTotalWeight() uses).
      *
      * @param int $capacityScaled
      * @param int $rawUnitWeightScaled
@@ -280,6 +299,8 @@ class Package
     }
 
     /**
+     * Returns the total price of all items in the package.
+     *
      * @return float
      */
     public function getTotalPrice()
@@ -295,6 +316,8 @@ class Package
     }
 
     /**
+     * Checks whether the given item is already in the package.
+     *
      * @param QuoteItem $item
      *
      * @return bool
@@ -305,6 +328,8 @@ class Package
     }
 
     /**
+     * Returns the quantity already added for the given item.
+     *
      * @param QuoteItem $item
      *
      * @return float

--- a/Model/Packages/Package.php
+++ b/Model/Packages/Package.php
@@ -16,6 +16,7 @@ declare(strict_types = 1);
 namespace Frenet\Shipping\Model\Packages;
 
 use Frenet\Shipping\Model\Catalog\Product\DimensionsExtractorInterface;
+use Frenet\Shipping\Model\WeightConverterInterface;
 use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
 
 /**
@@ -49,14 +50,21 @@ class Package
      */
     private $packageItemFactory;
 
+    /**
+     * @var WeightConverterInterface
+     */
+    private $weightConverter;
+
     public function __construct(
         DimensionsExtractorInterface $dimensionsExtractor,
         PackageItemFactory $packageItemFactory,
-        PackageLimit $packageLimit
+        PackageLimit $packageLimit,
+        WeightConverterInterface $weightConverter
     ) {
         $this->dimensionsExtractor = $dimensionsExtractor;
         $this->packageItemFactory = $packageItemFactory;
         $this->packageLimit = $packageLimit;
+        $this->weightConverter = $weightConverter;
     }
 
     /**
@@ -109,10 +117,25 @@ class Package
      */
     public function canAddItem(QuoteItem $item, $qty = 1)
     {
+        if ($qty <= 0) {
+            return true;
+        }
+
         $this->dimensionsExtractor->setProductByCartItem($item);
 
         $weight = $this->dimensionsExtractor->getWeight();
-        $itemWeight = $weight * $qty;
+
+        /**
+         * A primeira unidade do lote é comparada usando o peso cru (igual
+         * ao comportamento original com $qty=1); as unidades seguintes do
+         * mesmo lote somam o peso convertido, que é a mesma base usada por
+         * getTotalWeight() (soma de PackageItem::getTotalWeight(), que já
+         * passa por WeightConverter::convertToKg()). Sem isso, um lote com
+         * $qty > 1 seria comparado de forma inconsistente com a soma que
+         * getTotalWeight() reporta para o mesmo lote depois de adicionado.
+         */
+        $convertedWeight = (float) $this->weightConverter->convertToKg($weight);
+        $itemWeight = $weight + $convertedWeight * ($qty - 1);
 
         if (($itemWeight + $this->getTotalWeight()) > $this->packageLimit->getMaxWeight()) {
             return false;
@@ -156,6 +179,18 @@ class Package
      * item anterior); os lotes seguintes (newPackage => true) assumem
      * sempre um pacote novo e vazio, com capacidade cheia.
      *
+     * canAddItem() compara o peso *cru* do item sendo adicionado com o
+     * peso *convertido para kg* já acumulado no pacote (getTotalWeight()
+     * soma PackageItem::getTotalWeight(), que passa por
+     * WeightConverter::convertToKg()) -- uma inconsistência pré-existente
+     * que só produz efeito quando a loja não está configurada em kg
+     * (general/locale/weight_unit != "kgs", que é inclusive o valor
+     * padrão de fábrica do Magento_Directory). Para que o resultado do
+     * empacotamento continue idêntico ao algoritmo unidade-por-unidade
+     * mesmo nesse cenário, unitsFitting() replica exatamente essa mesma
+     * mistura cru/convertido, em vez de assumir peso uniforme dos dois
+     * lados da conta.
+     *
      * @param QuoteItem $item
      * @param float     $requestedQty
      *
@@ -170,11 +205,14 @@ class Package
             return [['newPackage' => false, 'qty' => $requestedQty]];
         }
 
+        $convertedUnitWeight = (float) $this->weightConverter->convertToKg($unitWeight);
+
         $unitWeightScaled = (int) round($unitWeight * self::WEIGHT_SCALE);
+        $convertedUnitWeightScaled = (int) round($convertedUnitWeight * self::WEIGHT_SCALE);
         $fullCapacityScaled = (int) round($this->packageLimit->getMaxWeight() * self::WEIGHT_SCALE);
         $remainingScaled = max(0, (int) round($this->getRemainingWeight() * self::WEIGHT_SCALE));
 
-        $unitsPerFullPackage = intdiv($fullCapacityScaled, $unitWeightScaled);
+        $unitsPerFullPackage = $this->unitsFitting($fullCapacityScaled, $unitWeightScaled, $convertedUnitWeightScaled);
 
         if ($unitsPerFullPackage < 1) {
             /**
@@ -188,7 +226,10 @@ class Package
         }
 
         $requestedQtyInt = (int) $requestedQty;
-        $firstBatch = min($requestedQtyInt, intdiv($remainingScaled, $unitWeightScaled));
+        $firstBatch = min(
+            $requestedQtyInt,
+            $this->unitsFitting($remainingScaled, $unitWeightScaled, $convertedUnitWeightScaled)
+        );
         $remaining = $requestedQtyInt - $firstBatch;
 
         $plan = [];
@@ -212,6 +253,28 @@ class Package
         }
 
         return $plan;
+    }
+
+    /**
+     * Quantas unidades de peso cru $rawUnitWeightScaled (com equivalente
+     * convertido $convertedUnitWeightScaled) cabem numa capacidade
+     * $capacityScaled, replicando a semântica de canAddItem(): a primeira
+     * unidade é comparada usando peso cru; cada unidade adicional soma o
+     * peso convertido (mesma base usada por getTotalWeight()).
+     *
+     * @param int $capacityScaled
+     * @param int $rawUnitWeightScaled
+     * @param int $convertedUnitWeightScaled
+     *
+     * @return int
+     */
+    private function unitsFitting(int $capacityScaled, int $rawUnitWeightScaled, int $convertedUnitWeightScaled): int
+    {
+        if ($rawUnitWeightScaled > $capacityScaled) {
+            return 0;
+        }
+
+        return intdiv($capacityScaled - $rawUnitWeightScaled, $convertedUnitWeightScaled) + 1;
     }
 
     /**

--- a/Model/Packages/PackageItemDistributor.php
+++ b/Model/Packages/PackageItemDistributor.php
@@ -55,27 +55,40 @@ class PackageItemDistributor
      */
     public function distribute(): array
     {
-        return $this->getUnitItems();
+        return $this->getGroupedItems();
     }
 
     /**
-     * @return array
+     * Retorna um par item+qty por linha válida da quote, sem explodir a
+     * quantidade em cópias unitárias (ver Package::planQuantitiesFor(),
+     * que faz esse trabalho por aritmética quando o pacote é montado).
+     *
+     * A quantidade é truncada (floor) para preservar o comportamento já
+     * existente do algoritmo anterior, que descartava implicitamente a
+     * parte fracionária de itens com "Qty Uses Decimals" habilitado.
+     *
+     * @return array{item: QuoteItem, qty: float}[]
      */
-    private function getUnitItems(): array
+    private function getGroupedItems(): array
     {
         $rateRequest = $this->rateRequestProvider->getRateRequest();
-        $unitItems = [];
+        $groupedItems = [];
 
         /** @var QuoteItem $item */
         foreach ($rateRequest->getAllItems() as $item) {
             if (!$this->quoteItemValidator->validate($item)) {
                 continue;
             }
-            $qty = $this->itemQuantityCalculator->calculate($item);
-            for ($idx = 1; $idx <= $qty; $idx++) {
-                $unitItems[] = $item;
+
+            $qty = floor($this->itemQuantityCalculator->calculate($item));
+
+            if ($qty < 1) {
+                continue;
             }
+
+            $groupedItems[] = ['item' => $item, 'qty' => $qty];
         }
-        return $unitItems;
+
+        return $groupedItems;
     }
 }

--- a/Model/Packages/PackageItemDistributor.php
+++ b/Model/Packages/PackageItemDistributor.php
@@ -68,11 +68,6 @@ class PackageItemDistributor
     /**
      * Returns one item+qty pair per valid quote line, without exploding the quantity into unit copies.
      *
-     * Package::planQuantitiesFor() does that split arithmetically when the
-     * package is built. The quantity is truncated (floor) to preserve the
-     * previous algorithm's behavior, which implicitly discarded the
-     * fractional part of items with "Qty Uses Decimals" enabled.
-     *
      * @return array{item: QuoteItem, qty: float}[]
      */
     private function getGroupedItems(): array

--- a/Model/Packages/PackageItemDistributor.php
+++ b/Model/Packages/PackageItemDistributor.php
@@ -40,6 +40,11 @@ class PackageItemDistributor
      */
     private $rateRequestProvider;
 
+    /**
+     * @param QuoteItemValidatorInterface $quoteItemValidator
+     * @param ItemQuantityCalculator      $itemQuantityCalculator
+     * @param RateRequestProvider         $rateRequestProvider
+     */
     public function __construct(
         QuoteItemValidatorInterface $quoteItemValidator,
         ItemQuantityCalculator $itemQuantityCalculator,
@@ -51,6 +56,8 @@ class PackageItemDistributor
     }
 
     /**
+     * Returns the quote items grouped with their quantity, ready to be packed.
+     *
      * @return array
      */
     public function distribute(): array
@@ -59,13 +66,12 @@ class PackageItemDistributor
     }
 
     /**
-     * Retorna um par item+qty por linha válida da quote, sem explodir a
-     * quantidade em cópias unitárias (ver Package::planQuantitiesFor(),
-     * que faz esse trabalho por aritmética quando o pacote é montado).
+     * Returns one item+qty pair per valid quote line, without exploding the quantity into unit copies.
      *
-     * A quantidade é truncada (floor) para preservar o comportamento já
-     * existente do algoritmo anterior, que descartava implicitamente a
-     * parte fracionária de itens com "Qty Uses Decimals" habilitado.
+     * Package::planQuantitiesFor() does that split arithmetically when the
+     * package is built. The quantity is truncated (floor) to preserve the
+     * previous algorithm's behavior, which implicitly discarded the
+     * fractional part of items with "Qty Uses Decimals" enabled.
      *
      * @return array{item: QuoteItem, qty: float}[]
      */

--- a/Model/Packages/PackageLimit.php
+++ b/Model/Packages/PackageLimit.php
@@ -15,16 +15,13 @@ declare(strict_types = 1);
 
 namespace Frenet\Shipping\Model\Packages;
 
+use Frenet\Shipping\Model\Config;
+
 /**
  * Class PackageLimit
  */
 class PackageLimit
 {
-    /**
-     * @var float
-     */
-    const PACKAGE_MAX_WEIGHT = 30.0000;
-
     /**
      * @var float
      */
@@ -36,17 +33,35 @@ class PackageLimit
     private $maxWeight = null;
 
     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Returns the maximum weight allowed for a package.
+     *
      * @return float
      */
     public function getMaxWeight()
     {
         if (null === $this->maxWeight) {
-            return self::PACKAGE_MAX_WEIGHT;
+            return $this->config->getPackageMaxWeight();
         }
+
         return (float) $this->maxWeight;
     }
 
     /**
+     * Overrides the package max weight for the current calculation.
+     *
      * @param float $weight
      *
      * @return $this
@@ -58,6 +73,8 @@ class PackageLimit
     }
 
     /**
+     * Removes the package weight limit for the current calculation.
+     *
      * @return $this
      */
     public function removeLimit()
@@ -66,6 +83,8 @@ class PackageLimit
     }
 
     /**
+     * Checks whether the package weight limit is currently disabled.
+     *
      * @return bool
      */
     public function isUnlimited()
@@ -74,6 +93,8 @@ class PackageLimit
     }
 
     /**
+     * Restores the configured package max weight.
+     *
      * @return $this
      */
     public function resetMaxWeight()
@@ -83,6 +104,8 @@ class PackageLimit
     }
 
     /**
+     * Checks whether the given weight exceeds the package max weight.
+     *
      * @param float $weight
      *
      * @return bool

--- a/Model/Packages/PackageManager.php
+++ b/Model/Packages/PackageManager.php
@@ -61,8 +61,6 @@ class PackageManager
     private $packageItemDistributor;
 
     /**
-     * PackageManager constructor.
-     *
      * @param QuoteItemValidatorInterface     $quoteItemValidator
      * @param ItemQuantityCalculatorInterface $itemQuantityCalculator
      * @param PackageFactory                  $packageFactory
@@ -84,6 +82,8 @@ class PackageManager
     }
 
     /**
+     * Distributes the quote items into packages.
+     *
      * @return $this
      */
     public function process(): self
@@ -96,6 +96,8 @@ class PackageManager
     }
 
     /**
+     * Returns the packages built so far.
+     *
      * @return Package[]
      */
     public function getPackages(): array
@@ -104,6 +106,8 @@ class PackageManager
     }
 
     /**
+     * Returns the number of packages built so far.
+     *
      * @return int
      */
     public function countPackages()
@@ -112,6 +116,8 @@ class PackageManager
     }
 
     /**
+     * Clears the current package reference.
+     *
      * @return $this
      */
     public function unsetCurrentPackage()
@@ -121,6 +127,8 @@ class PackageManager
     }
 
     /**
+     * Clears all built packages.
+     *
      * @return $this
      */
     public function resetPackages() : self
@@ -131,6 +139,8 @@ class PackageManager
     }
 
     /**
+     * Creates a new, empty package.
+     *
      * @return Package
      */
     public function createPackage()
@@ -139,6 +149,8 @@ class PackageManager
     }
 
     /**
+     * Applies a quote item's packing plan, opening new packages as needed.
+     *
      * @param QuoteItem $item
      * @param float     $qty
      *
@@ -157,6 +169,8 @@ class PackageManager
     }
 
     /**
+     * Returns the current package, creating one if none exists yet.
+     *
      * @return Package
      */
     private function getPackage()
@@ -169,6 +183,8 @@ class PackageManager
     }
 
     /**
+     * Starts a new current package and registers it.
+     *
      * @return $this
      */
     private function useNewPackage()

--- a/Model/Packages/PackageManager.php
+++ b/Model/Packages/PackageManager.php
@@ -152,7 +152,7 @@ class PackageManager
             if ($batch['newPackage']) {
                 $this->useNewPackage();
             }
-            $this->getPackage()->addItem($item, $batch['qty']);
+            $this->getPackage()->addItem($item, $batch['qty'], $batch['unitWeight']);
         }
     }
 

--- a/Model/Packages/PackageManager.php
+++ b/Model/Packages/PackageManager.php
@@ -88,11 +88,8 @@ class PackageManager
      */
     public function process(): self
     {
-        $items = $this->packageItemDistributor->distribute();
-
-        /** @var QuoteItem $item */
-        foreach ($items as $item) {
-            $this->addItemToPackage($item);
+        foreach ($this->packageItemDistributor->distribute() as $entry) {
+            $this->addItemToPackage($entry['item'], $entry['qty']);
         }
 
         return $this;
@@ -143,16 +140,20 @@ class PackageManager
 
     /**
      * @param QuoteItem $item
+     * @param float     $qty
      *
-     * @return bool
+     * @return void
      */
-    private function addItemToPackage(QuoteItem $item)
+    private function addItemToPackage(QuoteItem $item, float $qty): void
     {
-        if (!$this->getPackage()->canAddItem($item, 1)) {
-            $this->useNewPackage();
-        }
+        $plan = $this->getPackage()->planQuantitiesFor($item, $qty);
 
-        return $this->getPackage()->addItem($item, 1);
+        foreach ($plan as $batch) {
+            if ($batch['newPackage']) {
+                $this->useNewPackage();
+            }
+            $this->getPackage()->addItem($item, $batch['qty']);
+        }
     }
 
     /**

--- a/Model/Packages/PackageManager.php
+++ b/Model/Packages/PackageManager.php
@@ -36,7 +36,7 @@ class PackageManager
     private $packages = [];
 
     /**
-     * @var \Frenet\Shipping\Model\Packages\PackageFactory
+     * @var PackageFactory
      */
     private $packageFactory;
 

--- a/Model/Quote/ItemQuantityCalculator.php
+++ b/Model/Quote/ItemQuantityCalculator.php
@@ -29,12 +29,17 @@ class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
      */
     private $config;
 
+    /**
+     * @param Config $config
+     */
     public function __construct(Config $config)
     {
         $this->config = $config;
     }
 
     /**
+     * Calculates the effective quantity of a quote item, capped at the configured maximum.
+     *
      * @param QuoteItem $item
      *
      * @return float
@@ -71,6 +76,8 @@ class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
     }
 
     /**
+     * Returns the quantity for a simple product.
+     *
      * @param QuoteItem $item
      *
      * @return float
@@ -81,6 +88,8 @@ class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
     }
 
     /**
+     * Returns the quantity for a bundle product, scaled by the parent item's quantity.
+     *
      * @param QuoteItem $item
      *
      * @return float
@@ -92,6 +101,8 @@ class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
     }
 
     /**
+     * Returns the quantity for a grouped product.
+     *
      * @param QuoteItem $item
      *
      * @return float
@@ -102,7 +113,7 @@ class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
     }
 
     /**
-     * The right quantity for configurable products are on the parent item.
+     * Returns the quantity for a configurable product, which lives on the parent item.
      *
      * @param QuoteItem $item
      *

--- a/Model/Quote/ItemQuantityCalculator.php
+++ b/Model/Quote/ItemQuantityCalculator.php
@@ -16,6 +16,7 @@ declare(strict_types = 1);
 namespace Frenet\Shipping\Model\Quote;
 
 use Frenet\Shipping\Model\Catalog\ProductType;
+use Frenet\Shipping\Model\Config;
 use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
 
 /**
@@ -23,6 +24,16 @@ use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
  */
 class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
 {
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param QuoteItem $item
      *
@@ -56,7 +67,7 @@ class ItemQuantityCalculator implements ItemQuantityCalculatorInterface
                 $qty = $this->calculateSimpleProduct($item);
         }
 
-        return (float) max(1, $qty);
+        return (float) min($this->config->getMaxUnitQuantity(), max(1, $qty));
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -1,29 +1,96 @@
 # Frenet Gateway de Fretes para Magento 2
-Integre seu Magento 2 aos serviços da Frenet de forma rápida e fácil.
 
-[![Build Status](https://travis-ci.org/FrenetGatewaydeFretes/frenet-magento2.svg?branch=2.2-develop)](https://travis-ci.org/FrenetGatewaydeFretes/frenet-magento2)
-![Packagist](https://img.shields.io/packagist/dt/frenet/frenet-magento2)
-[![PHP v7.0](https://img.shields.io/badge/php-v7.0-blue.svg)](http://www.php.net)
-[![Magento v2.3](https://img.shields.io/badge/magento-v2.3-green.svg)](https://magento.com/)
-[![Magento v2.4](https://img.shields.io/badge/magento-v2.4-green.svg)](https://magento.com/)
+Integre sua loja Magento 2 aos serviços da [Frenet](https://www.frenet.com.br/) e ofereça cotação de frete em tempo real (Correios, transportadoras e Jadlog, entre outras) direto no carrinho, no checkout e na página de produto.
+
+[![Packagist Version](https://img.shields.io/packagist/v/frenet/frenet-magento2)](https://packagist.org/packages/frenet/frenet-magento2)
+![Packagist Downloads](https://img.shields.io/packagist/dt/frenet/frenet-magento2)
+[![PHP](https://img.shields.io/badge/php-8.2%20%7C%208.3%20%7C%208.4-blue.svg)](http://www.php.net)
+[![Magento](https://img.shields.io/badge/magento-2.4-orange.svg)](https://magento.com/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
+
+## Funcionalidades
+
+- **Cotação de frete em tempo real** no carrinho e no checkout, via API da Frenet, com todas as transportadoras habilitadas na sua conta (Correios, Jadlog, transportadoras parceiras, etc).
+- **Cotação de frete na página de produto**, antes de adicionar ao carrinho — configurável por tipo de produto (simples, configurável, bundle, agrupado).
+- **Divisão automática em múltiplos pacotes** (*multi-quote*) quando o peso total do carrinho excede o limite de um único pacote (30kg), com cálculo de empacotamento O(1) independente da quantidade de itens.
+- **Mapeamento de atributos de produto** para peso, altura, largura e comprimento — use os atributos padrão ou aponte para atributos customizados do seu catálogo.
+- **Rastreio de encomendas** integrado (`Model/Tracking.php`), exibindo o status de entrega da Frenet direto no Magento.
+- **Mensagem de previsão de entrega** configurável, com placeholder de prazo em dias (`{{d}}`).
+- **Restrição por país e método de envio**, prazo adicional configurável, e opção de exibir ou ocultar métodos indisponíveis.
+- **Log de depuração** opcional, para investigar requisições/respostas trocadas com a API da Frenet.
+- **Limite de segurança configurável** para a quantidade de um mesmo item considerada no empacotamento (`Maximum Item Quantity per Shipping Line`), protegendo o cálculo de frete contra quantidades excessivas.
+- Tradução para **pt-BR** incluída.
 
 ## Compatibilidade
 
-Esta versão do módulo é compatível com as seguintes versões do Magento 2:
+| Módulo | Magento | PHP |
+|---|---|---|
+| `2.4.8-p1` | 2.4.8 / 2.4.8-p1 | 8.2, 8.3, 8.4 |
 
-- Magento 2.3
-- Magento 2.4
+O `composer.json` do módulo declara as versões de `magento/framework` e dos módulos `magento/module-*` suportadas; o Composer resolve automaticamente a versão compatível com a sua instalação. Para versões anteriores do Magento (2.3.x, 2.4.0–2.4.7), utilize uma tag anterior do módulo (ex.: `2.4.7-p3`).
+
+## Pré-requisitos
+
+- Uma conta ativa na Frenet e um **token de API**, obtido em [painel.frenet.com.br](http://painel.frenet.com.br/).
+- [Composer](https://getcomposer.org/) instalado no ambiente onde o Magento roda.
+
+> É recomendado validar a instalação e qualquer atualização em um ambiente de testes antes de aplicar em produção.
 
 ## Instalação
-> É recomendado que você tenha um ambiente de testes para validar alterações e atualizações antes de atualizar sua loja em produção.
 
-> A instalação do módulo é feita utilizando o Composer. Para baixar e instalar o Composer no seu ambiente acesse https://getcomposer.org/download/ e caso tenha dúvidas de como utilizá-lo consulte a [documentação oficial do Composer](https://getcomposer.org/doc/).
+Abra o terminal na raiz da sua instalação do Magento 2 e execute:
 
-Abra o terminal e navegue até o diretório raíz da sua instalação do Magento 2 e execute os seguintes comandos:
-
+```bash
+composer require frenet/frenet-magento2       # Baixa e requer o módulo
+php bin/magento module:enable Frenet_Shipping # Ativa o módulo
+php bin/magento setup:upgrade                 # Aplica os patches de setup do módulo
+php bin/magento setup:di:compile              # Recompila o projeto (obrigatório em modo production)
+php bin/magento cache:flush                   # Limpa o cache
 ```
-> composer require frenet/frenet-magento2        // Faz a requisição do módulo da Frenet
-> php bin/magento module:enable Frenet_Shipping  // Ativa o módulo no Magento
-> php bin/magento setup:upgrade                  // Registra a extensão
-> php bin/magento setup:di:compile               // Recompila o projeto Magento
+
+Se você quiser fixar uma versão específica em vez do último release, informe a constraint diretamente:
+
+```bash
+composer require frenet/frenet-magento2:^2.4.8-p1
 ```
+
+## Configuração
+
+No admin do Magento, acesse **Stores > Configuration > Sales > Delivery Methods > Frenet Shipping Gateway** e configure, no mínimo:
+
+1. **Enabled**: ative o método.
+2. **API Token**: cole o token obtido no painel da Frenet.
+3. **Attributes Mapping**: confirme (ou ajuste) quais atributos do produto representam peso, altura, largura e comprimento.
+4. **Default Measurements**: valores usados quando um produto não tem essas dimensões preenchidas.
+
+Recursos opcionais, no mesmo painel:
+
+- **Enable Multi Quote**: divide o carrinho em múltiplos pacotes quando o peso total ultrapassa 30kg (uma chamada de API por pacote gerado).
+- **Maximum Item Quantity per Shipping Line**: teto de segurança (padrão 5000) para a quantidade de um mesmo item considerada no cálculo de pacotes.
+- **Product Quote**: habilita a cotação de frete diretamente na página de produto, antes do cliente adicionar ao carrinho.
+- **Show Shipping Forecast** / **Shipping Forecast Message**: exibe uma mensagem de prazo estimado de entrega.
+- **Debug**: grava as requisições/respostas da API da Frenet em `var/log/<Debug Filename>`, útil para diagnosticar problemas de cotação.
+
+## Como funciona
+
+- **Checkout/carrinho**: o Magento consulta `Frenet\Shipping\Model\Carrier\Frenet::collectRates()` durante a estimativa de frete, que monta os pacotes a partir dos itens do carrinho e consulta a API da Frenet, retornando as opções de envio disponíveis.
+- **Página de produto**: se **Product Quote** estiver habilitado, o widget consulta o mesmo mecanismo de cotação para um único produto e quantidade informados, sem a necessidade de adicionar ao carrinho antes.
+- **Rastreio**: pedidos com código de rastreio da Frenet exibem o status de entrega consultado via `getTracking()`.
+
+## Suporte
+
+- Dúvidas sobre a API/token da Frenet: [contato@frenet.com.br](mailto:contato@frenet.com.br) ou o [painel da Frenet](http://painel.frenet.com.br/).
+- Bugs e sugestões neste módulo: abra uma [issue no GitHub](https://github.com/FrenetGatewaydeFretes/frenet-magento2/issues).
+
+## Desenvolvimento
+
+O módulo segue o padrão de código `Magento2` (PHPCS) e PHPMD. Para rodar as verificações localmente:
+
+```bash
+composer coding-standard   # phpcs + phpmd
+composer phpunit           # testes unitários
+```
+
+## Licença
+
+Distribuído sob a licença [MIT](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Integre sua loja Magento 2 aos serviços da [Frenet](https://www.frenet.com.br/)
 
 - **Cotação de frete em tempo real** no carrinho e no checkout, via API da Frenet, com todas as transportadoras habilitadas na sua conta (Correios, Jadlog, transportadoras parceiras, etc).
 - **Cotação de frete na página de produto**, antes de adicionar ao carrinho — configurável por tipo de produto (simples, configurável, bundle, agrupado).
-- **Divisão automática em múltiplos pacotes** (*multi-quote*) quando o peso total do carrinho excede o limite de um único pacote (30kg), com cálculo de empacotamento O(1) independente da quantidade de itens.
+- **Divisão automática em múltiplos pacotes** (*multi-quote*) quando o peso total do carrinho excede o peso máximo configurado por pacote (padrão 30kg), com cálculo de empacotamento O(1) independente da quantidade de itens.
 - **Mapeamento de atributos de produto** para peso, altura, largura e comprimento — use os atributos padrão ou aponte para atributos customizados do seu catálogo.
 - **Rastreio de encomendas** integrado (`Model/Tracking.php`), exibindo o status de entrega da Frenet direto no Magento.
 - **Mensagem de previsão de entrega** configurável, com placeholder de prazo em dias (`{{d}}`).
@@ -65,7 +65,8 @@ No admin do Magento, acesse **Stores > Configuration > Sales > Delivery Methods 
 
 Recursos opcionais, no mesmo painel:
 
-- **Enable Multi Quote**: divide o carrinho em múltiplos pacotes quando o peso total ultrapassa 30kg (uma chamada de API por pacote gerado).
+- **Enable Multi Quote**: divide o carrinho em múltiplos pacotes quando o peso total ultrapassa o **Package Max Weight** (uma chamada de API por pacote gerado).
+- **Package Max Weight (kg)**: peso máximo por pacote em quilogramas (padrão 30). Só precisa ser alterado se houver instrução específica.
 - **Maximum Item Quantity per Shipping Line**: teto de segurança (padrão 5000) para a quantidade de um mesmo item considerada no cálculo de pacotes.
 - **Product Quote**: habilita a cotação de frete diretamente na página de produto, antes do cliente adicionar ao carrinho.
 - **Show Shipping Forecast** / **Shipping Forecast Message**: exibe uma mensagem de prazo estimado de entrega.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "frenet/frenet-magento2",
     "type": "magento2-module",
-    "version": "2.4.7.5",
+    "version": "2.4.8-p1",
     "autoload": {
         "files": [
             "registration.php"
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^7.0|>=8.0",
+        "php": "~8.2.0||~8.3.0||~8.4.0",
         "frenet/frenet-php": "^1.3.2",
         "symfony/finder": "^v6.4",
         "magento/framework": "^101.0.0|^102.0.0|^103.0.0|^104.0.0",
@@ -38,7 +38,7 @@
         "magento/module-store": "^101.0.0"
     },
     "require-dev": {
-        "magento/magento-coding-standard": "~4.0.0",
+        "magento/magento-coding-standard": ">=4",
         "phpmd/phpmd": "@stable"
     },
     "license": "proprietary",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -51,7 +51,14 @@
                 <field id="multi_quote" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Multi Quote</label>
                     <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
-                    <comment><![CDATA[When the cart's total weight is greater than the limit (30kg) multiple calls will be done for Correios.<br/><br/><b>Note</b>: with this feature enabled you'll need to ship the products in diferent packages.<br/><br/><b style='color:red;'>Warning</b>: The shipping rules and restrictions based in cart total or weight may not work properly when this option is enabled.]]></comment>
+                    <comment><![CDATA[When the cart's total weight is greater than the package max weight, multiple calls will be done for Correios.<br/><br/><b>Note</b>: with this feature enabled you'll need to ship the products in diferent packages.<br/><br/><b style='color:red;'>Warning</b>: The shipping rules and restrictions based in cart total or weight may not work properly when this option is enabled.]]></comment>
+                </field>
+
+                <!-- PACKAGE MAX WEIGHT -->
+                <field id="package_max_weight" translate="label comment" type="text" sortOrder="75" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Package Max Weight (kg)</label>
+                    <validate>validate-number validate-greater-than-zero</validate>
+                    <comment><![CDATA[Maximum weight per shipping package in kilograms. Used when Multi Quote is enabled to split the cart into multiple packages. Default is 30kg.]]></comment>
                 </field>
 
                 <!-- MAX UNIT QUANTITY (PACKAGE DISTRIBUTION SAFETY LIMIT) -->

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -54,6 +54,13 @@
                     <comment><![CDATA[When the cart's total weight is greater than the limit (30kg) multiple calls will be done for Correios.<br/><br/><b>Note</b>: with this feature enabled you'll need to ship the products in diferent packages.<br/><br/><b style='color:red;'>Warning</b>: The shipping rules and restrictions based in cart total or weight may not work properly when this option is enabled.]]></comment>
                 </field>
 
+                <!-- MAX UNIT QUANTITY (PACKAGE DISTRIBUTION SAFETY LIMIT) -->
+                <field id="max_unit_quantity" translate="label comment" type="text" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Maximum Item Quantity per Shipping Line</label>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                    <comment><![CDATA[Safety limit for the quantity of a single cart item considered while building shipping packages. Protects the package calculation from excessively large quantities. Leave empty to use the default (5000).]]></comment>
+                </field>
+
                 <!-- ATTRIBUTES MAPPING -->
                 <include path="Frenet_Shipping::system/attributes_mapping.xml"/>
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -50,6 +50,9 @@
                 <!-- ADDITIONAL LEAD TIME -->
                 <additional_lead_time>0</additional_lead_time>
 
+                <!-- PACKAGE MAX WEIGHT (KG) -->
+                <package_max_weight>30</package_max_weight>
+
                 <!-- MAX UNIT QUANTITY (PACKAGE DISTRIBUTION SAFETY LIMIT) -->
                 <max_unit_quantity>5000</max_unit_quantity>
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -50,6 +50,9 @@
                 <!-- ADDITIONAL LEAD TIME -->
                 <additional_lead_time>0</additional_lead_time>
 
+                <!-- MAX UNIT QUANTITY (PACKAGE DISTRIBUTION SAFETY LIMIT) -->
+                <max_unit_quantity>5000</max_unit_quantity>
+
                 <!-- DEFAULT MEASUREMENTS -->
                 <default_measurements>
                     <default_weight>1</default_weight>


### PR DESCRIPTION
## Resumo

Release `2.4.8` → `2.4.8-p1`.

Antes o AJAX de cotação na PDP aceitava `qty` sem teto e o packing rodava em loop por unidade — combinação ruim em loja aberta. A gente limitou a qty (mesma config do carrinho), reescreveu o split de pacotes em O(1), corrigiu um bug de unidade de peso que apareceu na validação, e expôs no admin o teto de qty e o peso máximo do pacote. Composer/PHP alinhados com Magento 2.4.8-p1.

## Segurança

O `Quote.php` da PDP montava o item direto do request, sem auth e sem teto de `qty`. Com `qty` absurdo dava pra estourar packing + chamadas à Frenet. Agora rejeita fora do intervalo válido usando `max_unit_quantity` (default 5000).

No carrinho o `ItemQuantityCalculator` também não tinha limite — mesmo config passa a valer lá e na PDP.

## Performance

`planQuantitiesFor` monta o plano com divisão/módulo em vez de clonar unidade a unidade. Mesmo resultado na maioria dos casos, ~30–50x mais rápido em qty alta (ex.: linha com 5000 unidades, ~126–142ms → ~2.5–4.9ms).

Na hora de aplicar o plano a gente já passa o `unitWeight` calculado, sem reextrair peso a cada lote.

## Bugs

`canAddItem` misturava peso cru com o acumulado já em kg. Só aparece quando a loja não está em `kgs` (padrão Magento é lbs). Achamos no before/after do refactor O(1); agora tudo passa pelo `WeightConverter`.

`unitsFitting` / conversão: guard contra fator 0 pra não estourar divisão por zero se alguém plugar um converter custom.

No controller, `qty` vai pra `int` de verdade (bate com `QuoteProductInterface`) e entrou `declare(strict_types=1)`.

## Config

- `package_max_weight` — default 30 kg. `PackageLimit` lê a config; a const `PACKAGE_MAX_WEIGHT` sai de cena.
- `max_unit_quantity` — default 5000, compartilhado entre carrinho e cotação da PDP (Carriers > Frenet Shipping Gateway).

## Código

Helper `jsonError()` no controller pra não repetir montagem de erro JSON. Tiramos comentário explicativo longo; PHPDoc curto nos arquivos tocados. README atualizado (features, compat, configs novas).

## Composer

Versão `2.4.8-p1`. PHP `~8.2.0||~8.3.0||~8.4.0`. `magento/magento-coding-standard` de `~4.0.0` pra `>=4`.

## Testes

Comparação before/after (stash vs código novo): packing igual nos cenários que a gente rodou, inclusive o edge em lbs que mostrou o bug de peso. Uma divergência conhecida e aceita: item unitário overweight agora gera 1 pacote “vazio” em vez de 2 (quirk do algoritmo antigo).

E2E HTTP no AJAX com API real da Frenet — sucesso, qty inválida e caminho de exceção.

`composer install` com `frenet/frenet-magento2:dev-2.4.8-develop` resolve limpo no Magento 2.4.8-p1 (Packagist + `repo.magento.com`), sem conflito de versão.