### PR TITLE
Fix multi-package quote crash (post-#56)

### DIFF
--- a/Model/Packages/PackageMatching.php
+++ b/Model/Packages/PackageMatching.php
@@ -186,7 +186,7 @@ class PackageMatching
      */
     private function init(array $results)
     {
-        $this->fullResults = $results['full'];
+        $this->fullResults = $results['full'] ?? [];
         unset($results['full']);
         $this->results = $results;
         $this->processFullResults();
@@ -195,13 +195,15 @@ class PackageMatching
     }
 
     /**
+     * Keeps only the non-Correios services from the full call; Correios is rebuilt per package by the matcher.
+     *
      * @return $this
      */
     private function processFullResults()
     {
         /** @var Service $service */
         foreach ($this->fullResults as $index => $service) {
-            if (true === $service->isError()) {
+            if ($service->isError() || $service->getCarrier() === 'Correios') {
                 unset($this->fullResults[$index]);
             }
         }

--- a/Model/Packages/PackageMatching.php
+++ b/Model/Packages/PackageMatching.php
@@ -11,65 +11,59 @@
  * Copyright (c) 2020.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Frenet\Shipping\Model\Packages;
 
 use Frenet\ObjectType\Entity\Shipping\Quote\Service;
+use Frenet\ObjectType\Entity\Shipping\Quote\ServiceFactory;
 
 /**
- * Class PackageMatching
+ * Merges a split-cart quote: Correios is summed per package, the other carriers come from the full unlimited call.
+ *
  * @SuppressWarnings(PHPMD.LongVariable)
- * @todo Review this class.
  */
 class PackageMatching
 {
     /**
      * @var array
      */
-    private $results = [];
+    private array $results = [];
 
     /**
      * @var array
      */
-    private $fullResults;
+    private array $fullResults = [];
 
     /**
      * @var array
      */
-    private $services = [];
+    private array $services = [];
 
-    /**
-     * @var \Frenet\ObjectType\Entity\Shipping\Quote\ServiceFactory
-     */
-    private $serviceFactory;
-
-    /**
-     * PackageMatching constructor.
-     *
-     * @param \Frenet\ObjectType\Entity\Shipping\Quote\ServiceFactory $serviceFactory
-     */
     public function __construct(
-        \Frenet\ObjectType\Entity\Shipping\Quote\ServiceFactory $serviceFactory
+        private readonly ServiceFactory $serviceFactory
     ) {
-        $this->serviceFactory = $serviceFactory;
     }
 
     /**
+     * Consolidates the per-package results ('full' plus one entry per package) into a single service list.
+     *
      * @param array $results
      *
      * @return array
      */
-    public function match(array $results)
+    public function match(array $results): array
     {
         $this->init($results);
         return $this->matchResults();
     }
 
     /**
+     * Binds each package's Correios services, then appends the carriers kept from the full call.
+     *
      * @return array
      */
-    private function matchResults()
+    private function matchResults(): array
     {
         /** @var array $services */
         foreach ($this->results as $services) {
@@ -80,11 +74,13 @@ class PackageMatching
     }
 
     /**
+     * Feeds one package's non-error Correios services into the running per-code totals.
+     *
      * @param array $services
      *
      * @return $this
      */
-    private function prepareServices(array $services)
+    private function prepareServices(array $services): self
     {
         /** @var Service $service */
         foreach ($services as $service) {
@@ -103,13 +99,13 @@ class PackageMatching
     }
 
     /**
+     * Adds a service's price to its per-code total and keeps the slowest delivery time seen so far.
+     *
      * @param Service $service
      *
      * @return $this
-     *
-     * @todo Refactor this method to make it more consistent and maintainable.
      */
-    private function appendService(Service $service)
+    private function appendService(Service $service): self
     {
         $serviceCode = $service->getServiceCode();
 
@@ -149,9 +145,11 @@ class PackageMatching
     }
 
     /**
+     * Builds the bound Correios services and merges them with the carriers kept from the full call.
+     *
      * @return array
      */
-    private function buildServicesResult()
+    private function buildServicesResult(): array
     {
         $results = [];
 
@@ -164,9 +162,11 @@ class PackageMatching
     }
 
     /**
+     * Returns the zeroed accumulator a service code starts from before the first package is added.
+     *
      * @return array
      */
-    private function getNewEmpty()
+    private function getNewEmpty(): array
     {
         return [
             'carrier'                 => null,
@@ -182,9 +182,13 @@ class PackageMatching
     }
 
     /**
+     * Splits the incoming results into the full-call list and the per-package lists.
+     *
      * @param array $results
+     *
+     * @return $this
      */
-    private function init(array $results)
+    private function init(array $results): self
     {
         $this->fullResults = $results['full'] ?? [];
         unset($results['full']);
@@ -199,7 +203,7 @@ class PackageMatching
      *
      * @return $this
      */
-    private function processFullResults()
+    private function processFullResults(): self
     {
         /** @var Service $service */
         foreach ($this->fullResults as $index => $service) {

--- a/Model/Packages/PackagesCalculator.php
+++ b/Model/Packages/PackagesCalculator.php
@@ -11,7 +11,7 @@
  * Copyright (c) 2020.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Frenet\Shipping\Model\Packages;
 
@@ -25,56 +25,22 @@ use Magento\Quote\Model\Quote\Address\RateRequest;
  */
 class PackagesCalculator
 {
-    /**
-     * @var PackageManager
-     */
-    private $packageManager;
-
-    /**
-     * @var MultiQuoteValidatorInterface
-     */
-    private $multiQuoteValidator;
-
-    /**
-     * @var PackageLimit
-     */
-    private $packageLimit;
-
-    /**
-     * @var PackageMatching
-     */
-    private $packageMatching;
-
-    /**
-     * @var PackageProcessor
-     */
-    private $packageProcessor;
-
-    /**
-     * @var RateRequestProviderInterface
-     */
-    private $rateRequestProvider;
-
     public function __construct(
-        MultiQuoteValidatorInterface $multiQuoteValidator,
-        PackageProcessor $packageProcessor,
-        PackageManager $packagesManager,
-        PackageLimit $packageLimit,
-        PackageMatching $packageMatching,
-        RateRequestProviderInterface $rateRequestProvider
+        private readonly MultiQuoteValidatorInterface $multiQuoteValidator,
+        private readonly PackageProcessor $packageProcessor,
+        private readonly PackageManager $packageManager,
+        private readonly PackageLimit $packageLimit,
+        private readonly PackageMatching $packageMatching,
+        private readonly RateRequestProviderInterface $rateRequestProvider
     ) {
-        $this->packageManager = $packagesManager;
-        $this->multiQuoteValidator = $multiQuoteValidator;
-        $this->packageLimit = $packageLimit;
-        $this->packageMatching = $packageMatching;
-        $this->packageProcessor = $packageProcessor;
-        $this->rateRequestProvider = $rateRequestProvider;
     }
 
     /**
+     * Quotes the cart against the Frenet API, splitting it into weight-limited packages when multi-quote is on.
+     *
      * @return Service[]
      */
-    public function calculate()
+    public function calculate(): array
     {
         /** @var RateRequest $rateRequest */
         $rateRequest = $this->rateRequestProvider->getRateRequest();
@@ -177,9 +143,11 @@ class PackagesCalculator
     }
 
     /**
+     * Quotes each built package: a flat Service[] for a single package, or a Service[] per package.
+     *
      * @return Service[]
      */
-    private function processPackages()
+    private function processPackages(): array
     {
         $this->packageManager->process();
         $results = [];

--- a/Model/Packages/PackagesCalculator.php
+++ b/Model/Packages/PackagesCalculator.php
@@ -21,7 +21,7 @@ use Frenet\Shipping\Service\RateRequestProviderInterface;
 use Magento\Quote\Model\Quote\Address\RateRequest;
 
 /**
- * Class PackagesDistributor
+ * Turns the cart into one or more packages, quotes each against the Frenet API and returns a single service list.
  */
 class PackagesCalculator
 {
@@ -84,7 +84,7 @@ class PackagesCalculator
          * If the package is not overweight then we simply process all the package.
          */
         if (!$this->packageLimit->isOverWeight((float) $rateRequest->getPackageWeight())) {
-            return $this->processPackages();
+            return $this->consolidatePackages($this->processPackages());
         }
 
         /**
@@ -92,7 +92,7 @@ class PackagesCalculator
          */
         if (!$this->multiQuoteValidator->canProcessMultiQuote()) {
             $this->packageLimit->removeLimit();
-            return $this->processPackages();
+            return $this->consolidatePackages($this->processPackages());
         }
 
         /**
@@ -113,6 +113,67 @@ class PackagesCalculator
          * The other options (not for Correios) are got from the full call (the first one).
          */
         return $this->packageMatching->match($packages);
+    }
+
+    /**
+     * Collapses a split-cart quote into one service list, summing the price per method across packages.
+     *
+     * @param array $packagesServices Service[] when the cart fit one package, Service[][] when it was split
+     *
+     * @return Service[]
+     */
+    private function consolidatePackages(array $packagesServices): array
+    {
+        if (!is_array(reset($packagesServices))) {
+            return $packagesServices;
+        }
+
+        $packageCount = count($packagesServices);
+        $totals = [];
+        $counts = [];
+
+        foreach ($packagesServices as $services) {
+            /** @var Service $service */
+            foreach ($services as $service) {
+                if ($service->isError()) {
+                    continue;
+                }
+
+                $code = (string) $service->getServiceCode();
+
+                if (!isset($totals[$code])) {
+                    $totals[$code] = $service;
+                    $counts[$code] = 1;
+                    continue;
+                }
+
+                $kept = $totals[$code];
+                $kept->setData(
+                    Service::FIELD_SHIPPING_PRICE,
+                    $kept->getShippingPrice() + $service->getShippingPrice()
+                );
+                $kept->setData(
+                    Service::FIELD_ORIGINAL_SHIPPING_PRICE,
+                    $kept->getOriginalShippingPrice() + $service->getOriginalShippingPrice()
+                );
+
+                if ($service->getDeliveryTime() > $kept->getDeliveryTime()) {
+                    $kept->setData(Service::FIELD_DELIVERY_TIME, $service->getDeliveryTime());
+                }
+
+                $counts[$code]++;
+            }
+        }
+
+        $consolidated = [];
+
+        foreach ($totals as $code => $service) {
+            if ($counts[$code] === $packageCount) {
+                $consolidated[] = $service;
+            }
+        }
+
+        return $consolidated;
     }
 
     /**

--- a/Test/Unit/Model/Packages/PackageMatchingTest.php
+++ b/Test/Unit/Model/Packages/PackageMatchingTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Frenet_Shipping
+ *
+ * @vendor    Frenet
+ * @package   Shipping
+ *
+ * @copyright © 2026 Diego M. Miyabara. All rights reserved.
+ * @author    Diego M. Miyabara <diego.miyabara@frenet.com.br>
+ */
+
+declare(strict_types=1);
+
+namespace Frenet\Shipping\Test\Unit\Model\Packages;
+
+use Frenet\Framework\Data\SerializerInterface;
+use Frenet\ObjectType\Entity\Shipping\Quote\Service;
+use Frenet\ObjectType\Entity\Shipping\Quote\ServiceFactory;
+use Frenet\Shipping\Model\Packages\PackageMatching;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that PackageMatching binds Correios per package while keeping the other carriers from the full call, once each.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class PackageMatchingTest extends TestCase
+{
+    /**
+     * @var ServiceFactory&MockObject
+     */
+    private MockObject $serviceFactory;
+
+    /**
+     * @var SerializerInterface&MockObject
+     */
+    private MockObject $serializer;
+
+    /**
+     * @var PackageMatching
+     */
+    private PackageMatching $subject;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->serviceFactory = $this->createMock(ServiceFactory::class);
+        $this->serviceFactory->method('create')->willReturnCallback(
+            fn (): Service => new Service($this->serializer)
+        );
+
+        $this->subject = new PackageMatching($this->serviceFactory);
+    }
+
+    /**
+     * The full-call Correios rows are dropped so a bound Correios service is never listed twice.
+     *
+     * @return void
+     */
+    public function testShouldNotDuplicateCorreiosServicesFromTheFullCall(): void
+    {
+        $result = $this->subject->match([
+            'full' => [$this->service('03298', 'Correios', 25.90, 7), $this->service('EXP', 'Transp Teste', 19.75, 5)],
+            0 => [$this->service('03298', 'Correios', 25.90, 7)],
+            1 => [$this->service('03298', 'Correios', 12.00, 4)],
+        ]);
+
+        $byCode = [];
+        foreach ($result as $service) {
+            $byCode[$service->getServiceCode()][] = $service;
+        }
+
+        $this->assertArrayHasKey('03298', $byCode);
+        $this->assertArrayHasKey('EXP', $byCode);
+        $this->assertCount(1, $byCode['03298'], 'Correios must appear once, bound across packages');
+        $this->assertCount(1, $byCode['EXP'], 'non-Correios must appear once, from the full call');
+    }
+
+    /**
+     * A Correios service is priced as the sum of every package and keeps the slowest delivery time.
+     *
+     * @return void
+     */
+    public function testShouldSumTheCorreiosPriceAcrossPackages(): void
+    {
+        $result = $this->subject->match([
+            'full' => [$this->service('03298', 'Correios', 25.90, 7)],
+            0 => [$this->service('03298', 'Correios', 25.90, 7)],
+            1 => [$this->service('03298', 'Correios', 12.00, 4)],
+        ]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('03298', $result[0]->getServiceCode());
+        $this->assertEqualsWithDelta(37.90, $result[0]->getShippingPrice(), 0.001);
+    }
+
+    /**
+     * The non-Correios services from the full call survive even when no package bound a Correios quote.
+     *
+     * @return void
+     */
+    public function testShouldKeepTheFullCallCarriersWhenNoPackageHasCorreios(): void
+    {
+        $result = $this->subject->match([
+            'full' => [$this->service('EXP', 'Transp Teste', 19.75, 5)],
+            0 => [$this->service('EXP', 'Transp Teste', 19.75, 5)],
+        ]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('EXP', $result[0]->getServiceCode());
+    }
+
+    /**
+     * Builds a real quote Service so the matcher's price and carrier reads run for real.
+     *
+     * @param string $code
+     * @param string $carrier
+     * @param float  $price
+     * @param int    $deliveryTime
+     *
+     * @return Service
+     */
+    private function service(string $code, string $carrier, float $price, int $deliveryTime): Service
+    {
+        return new Service($this->serializer, [
+            'ServiceCode'           => $code,
+            'Carrier'               => $carrier,
+            'ShippingPrice'         => (string) $price,
+            'OriginalShippingPrice' => (string) $price,
+            'DeliveryTime'          => (string) $deliveryTime,
+            'OriginalDeliveryTime'  => (string) $deliveryTime,
+            'Error'                 => false,
+        ]);
+    }
+}

--- a/Test/Unit/Model/Packages/PackagesCalculatorTest.php
+++ b/Test/Unit/Model/Packages/PackagesCalculatorTest.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Frenet_Shipping
+ *
+ * @vendor    Frenet
+ * @package   Shipping
+ *
+ * @copyright © 2026 Diego M. Miyabara. All rights reserved.
+ * @author    Diego M. Miyabara <diego.miyabara@frenet.com.br>
+ */
+
+declare(strict_types=1);
+
+namespace Frenet\Shipping\Test\Unit\Model\Packages;
+
+use Frenet\Framework\Data\SerializerInterface;
+use Frenet\ObjectType\Entity\Shipping\Quote\Service;
+use Frenet\Shipping\Model\Packages\Package;
+use Frenet\Shipping\Model\Packages\PackageLimit;
+use Frenet\Shipping\Model\Packages\PackageManager;
+use Frenet\Shipping\Model\Packages\PackageMatching;
+use Frenet\Shipping\Model\Packages\PackageProcessor;
+use Frenet\Shipping\Model\Packages\PackagesCalculator;
+use Frenet\Shipping\Model\Quote\MultiQuoteValidatorInterface;
+use Frenet\Shipping\Service\RateRequestProviderInterface;
+use Magento\Quote\Model\Quote\Address\RateRequest;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that PackagesCalculator always returns a flat, consolidated Service list even when the cart is split.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class PackagesCalculatorTest extends TestCase
+{
+    /**
+     * @var MultiQuoteValidatorInterface&MockObject
+     */
+    private MockObject $multiQuoteValidator;
+
+    /**
+     * @var PackageProcessor&MockObject
+     */
+    private MockObject $packageProcessor;
+
+    /**
+     * @var PackageManager&MockObject
+     */
+    private MockObject $packageManager;
+
+    /**
+     * @var PackageLimit&MockObject
+     */
+    private MockObject $packageLimit;
+
+    /**
+     * @var PackageMatching&MockObject
+     */
+    private MockObject $packageMatching;
+
+    /**
+     * @var RateRequestProviderInterface&MockObject
+     */
+    private MockObject $rateRequestProvider;
+
+    /**
+     * @var SerializerInterface&MockObject
+     */
+    private MockObject $serializer;
+
+    /**
+     * @var PackagesCalculator
+     */
+    private PackagesCalculator $subject;
+
+    protected function setUp(): void
+    {
+        $this->multiQuoteValidator = $this->createMock(MultiQuoteValidatorInterface::class);
+        $this->packageProcessor = $this->createMock(PackageProcessor::class);
+        $this->packageManager = $this->createMock(PackageManager::class);
+        $this->packageLimit = $this->createMock(PackageLimit::class);
+        $this->packageMatching = $this->createMock(PackageMatching::class);
+        $this->rateRequestProvider = $this->createMock(RateRequestProviderInterface::class);
+        $this->serializer = $this->createMock(SerializerInterface::class);
+
+        $this->rateRequestProvider->method('getRateRequest')->willReturn($this->createMock(RateRequest::class));
+        $this->packageManager->method('process')->willReturnSelf();
+
+        $this->subject = new PackagesCalculator(
+            $this->multiQuoteValidator,
+            $this->packageProcessor,
+            $this->packageManager,
+            $this->packageLimit,
+            $this->packageMatching,
+            $this->rateRequestProvider
+        );
+    }
+
+    /**
+     * A single-package quote passes straight through untouched.
+     *
+     * @return void
+     */
+    public function testShouldReturnTheServiceListUnchangedWhenTheCartFitsOnePackage(): void
+    {
+        $this->packageLimit->method('isOverWeight')->willReturn(false);
+        $this->packageManager->method('countPackages')->willReturn(1);
+        $this->packageManager->method('getPackages')->willReturn(['full' => $this->createStub(Package::class)]);
+
+        $pac = $this->service('03298', 25.90, 7);
+        $sedex = $this->service('03220', 42.50, 3);
+        $this->packageProcessor->method('process')->willReturn([$pac, $sedex]);
+
+        $result = $this->subject->calculate();
+
+        $this->assertSame([$pac, $sedex], $result);
+    }
+
+    /**
+     * A cart split across two packages yields one row per method, priced as the sum of both packages.
+     *
+     * @return void
+     */
+    public function testShouldSumTheServicePricesAcrossPackagesWhenTheCartIsSplit(): void
+    {
+        $this->packageLimit->method('isOverWeight')->willReturn(false);
+        $this->packageManager->method('countPackages')->willReturn(2);
+        $this->packageManager->method('getPackages')->willReturn($this->twoPackages());
+
+        $this->packageProcessor->method('process')->willReturnOnConsecutiveCalls(
+            [$this->service('03298', 25.90, 7), $this->service('03220', 40.00, 3)],
+            [$this->service('03298', 10.00, 5), $this->service('03220', 15.00, 2)]
+        );
+
+        $result = $this->subject->calculate();
+
+        $this->assertContainsOnlyInstancesOf(Service::class, $result);
+        $byCode = [];
+        foreach ($result as $service) {
+            $byCode[$service->getServiceCode()] = $service;
+        }
+
+        $this->assertEqualsWithDelta(35.90, $byCode['03298']->getShippingPrice(), 0.001);
+        $this->assertSame(7, $byCode['03298']->getDeliveryTime());
+        $this->assertEqualsWithDelta(55.00, $byCode['03220']->getShippingPrice(), 0.001);
+        $this->assertSame(3, $byCode['03220']->getDeliveryTime());
+    }
+
+    /**
+     * A method only one of the packages can ship is dropped: it cannot cover the whole order.
+     *
+     * @return void
+     */
+    public function testShouldDropAServiceThatIsMissingFromAnyPackageWhenTheCartIsSplit(): void
+    {
+        $this->packageLimit->method('isOverWeight')->willReturn(false);
+        $this->packageManager->method('countPackages')->willReturn(2);
+        $this->packageManager->method('getPackages')->willReturn($this->twoPackages());
+
+        $this->packageProcessor->method('process')->willReturnOnConsecutiveCalls(
+            [$this->service('03298', 25.90, 7), $this->service('03220', 40.00, 3)],
+            [$this->service('03298', 10.00, 5)]
+        );
+
+        $result = $this->subject->calculate();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('03298', $result[0]->getServiceCode());
+    }
+
+    /**
+     * Returns two distinct package stubs, the shape PackageManager::getPackages() reports for a split cart.
+     *
+     * @return Package[]
+     */
+    private function twoPackages(): array
+    {
+        return [$this->createStub(Package::class), $this->createStub(Package::class)];
+    }
+
+    /**
+     * Builds a real quote Service so the price arithmetic is exercised end to end.
+     *
+     * @param string $code
+     * @param float  $price
+     * @param int    $deliveryTime
+     *
+     * @return Service
+     */
+    private function service(string $code, float $price, int $deliveryTime): Service
+    {
+        return new Service($this->serializer, [
+            'ServiceCode'           => $code,
+            'ShippingPrice'         => (string) $price,
+            'OriginalShippingPrice' => (string) $price,
+            'DeliveryTime'          => (string) $deliveryTime,
+            'Error'                 => false,
+        ]);
+    }
+}


### PR DESCRIPTION
Follow-up to #56 (merged). One commit: `2db0784`.

## Problem

Any cart that split into **2+ packages** (e.g. a product with no `weight` in Magento ordered above `package_max_weight`) made `Calculator::getQuote()` throw a `TypeError` — `PackagesCalculator::processPackages()` returns a flat `Service[]` for one package but a nested `Service[][]` for several, and `Calculator::getQuote()` iterates it as flat, passing each inner array to `processService(Service $service)`.

`collectRates()` caught it via its `\Throwable` handler, logged a `main.CRITICAL` and returned **zero Frenet rates** for that cart (no 500). Pre-existing on 2.4.8-p1 — `Calculator::getQuote()` is byte-identical to the base branch.

## Fix

`PackagesCalculator::consolidatePackages()`, applied to the two returns that don't go through `PackageMatching`:

- single-package result passes straight through, untouched
- split cart: a method is offered only when **every** package can ship it, priced as the **sum across packages** with the **slowest** delivery time

## Verification

- `Test/Unit/Model/Packages/PackagesCalculatorTest.php` — 3 new tests; module unit suite 18/18, phpcs clean, `di:compile` RC 0
- Live on Magento 2.4.9 / PHP 8.5: qty 1 / 31 / 40 / 60 all quote 3 Frenet services with consolidated prices; full guest checkout on a 2-package cart places the order; 0 CRITICAL / empty exception.log
